### PR TITLE
feat: add session and transcript repository helpers

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,44 @@
+# Backend Foundation
+
+This folder contains the Sprint 1 backend foundation for the database and storage layer.
+
+## What is included
+
+- SQLite schema for `sessions` and `transcripts`
+- Database helpers for creating sessions and storing transcripts
+- Upload storage helper that writes files into `./uploads/`
+- A tiny CLI entrypoint to initialize the local database
+
+## Quick start
+
+Initialize the local database:
+
+```bash
+python3 -m backend.forum_ai_notetaker
+```
+
+Example usage inside Flask routes or the processing pipeline:
+
+```python
+from backend.forum_ai_notetaker import (
+    create_session,
+    get_transcript,
+    init_db,
+    list_sessions,
+    save_transcript,
+    save_uploaded_file,
+)
+
+init_db()
+
+stored_path = save_uploaded_file(request.files["recording"])
+session = create_session(
+    title="Week 3 Forum",
+    original_filename=request.files["recording"].filename,
+    stored_path=stored_path,
+)
+
+save_transcript(session["id"], "Raw Whisper transcript text")
+sessions = list_sessions()
+transcript = get_transcript(session["id"])
+```

--- a/backend/forum_ai_notetaker/__init__.py
+++ b/backend/forum_ai_notetaker/__init__.py
@@ -8,13 +8,16 @@ from .repository import (
     list_sessions,
     save_transcript,
 )
+from .storage import DEFAULT_UPLOAD_ROOT, save_uploaded_file
 
 __all__ = [
     "DEFAULT_DB_PATH",
+    "DEFAULT_UPLOAD_ROOT",
     "create_session",
     "get_session",
     "get_transcript",
     "init_db",
     "list_sessions",
     "save_transcript",
+    "save_uploaded_file",
 ]

--- a/backend/forum_ai_notetaker/__init__.py
+++ b/backend/forum_ai_notetaker/__init__.py
@@ -1,5 +1,20 @@
 """Database helpers for Forum AI Notetaker."""
 
 from .db import DEFAULT_DB_PATH, init_db
+from .repository import (
+    create_session,
+    get_session,
+    get_transcript,
+    list_sessions,
+    save_transcript,
+)
 
-__all__ = ["DEFAULT_DB_PATH", "init_db"]
+__all__ = [
+    "DEFAULT_DB_PATH",
+    "create_session",
+    "get_session",
+    "get_transcript",
+    "init_db",
+    "list_sessions",
+    "save_transcript",
+]

--- a/backend/forum_ai_notetaker/repository.py
+++ b/backend/forum_ai_notetaker/repository.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .db import get_connection, init_db
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _row_to_dict(row: Any) -> dict[str, Any] | None:
+    return dict(row) if row is not None else None
+
+
+def create_session(
+    title: str | None,
+    original_filename: str,
+    stored_path: str,
+    *,
+    status: str = "uploaded",
+    db_path: str | Path | None = None,
+) -> dict[str, Any]:
+    init_db(db_path)
+    now = _utc_now()
+    normalized_title = title or Path(original_filename).stem or "Untitled session"
+
+    with get_connection(db_path) as connection:
+        cursor = connection.execute(
+            """
+            INSERT INTO sessions (
+                title,
+                original_filename,
+                stored_path,
+                status,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (normalized_title, original_filename, stored_path, status, now, now),
+        )
+        connection.commit()
+        session_id = cursor.lastrowid
+
+    session = get_session(session_id, db_path=db_path)
+    if session is None:
+        raise RuntimeError("Session was created but could not be loaded.")
+    return session
+
+
+def get_session(
+    session_id: int,
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, Any] | None:
+    init_db(db_path)
+    with get_connection(db_path) as connection:
+        row = connection.execute(
+            """
+            SELECT
+                sessions.id,
+                sessions.title,
+                sessions.original_filename,
+                sessions.stored_path,
+                sessions.status,
+                sessions.created_at,
+                sessions.updated_at,
+                transcripts.id IS NOT NULL AS has_transcript
+            FROM sessions
+            LEFT JOIN transcripts
+                ON transcripts.session_id = sessions.id
+            WHERE sessions.id = ?
+            """,
+            (session_id,),
+        ).fetchone()
+    return _row_to_dict(row)
+
+
+def save_transcript(
+    session_id: int,
+    content: str,
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, Any]:
+    init_db(db_path)
+    now = _utc_now()
+
+    with get_connection(db_path) as connection:
+        session_exists = connection.execute(
+            "SELECT 1 FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        if session_exists is None:
+            raise ValueError(f"Session {session_id} does not exist.")
+
+        connection.execute(
+            """
+            INSERT INTO transcripts (
+                session_id,
+                content,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                content = excluded.content,
+                updated_at = excluded.updated_at
+            """,
+            (session_id, content, now, now),
+        )
+        connection.execute(
+            """
+            UPDATE sessions
+            SET status = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            ("transcribed", now, session_id),
+        )
+        connection.commit()
+
+    transcript = get_transcript(session_id, db_path=db_path)
+    if transcript is None:
+        raise RuntimeError("Transcript was saved but could not be loaded.")
+    return transcript
+
+
+def get_transcript(
+    session_id: int,
+    *,
+    db_path: str | Path | None = None,
+) -> dict[str, Any] | None:
+    init_db(db_path)
+    with get_connection(db_path) as connection:
+        row = connection.execute(
+            """
+            SELECT
+                sessions.id AS session_id,
+                sessions.title,
+                sessions.original_filename,
+                sessions.stored_path,
+                sessions.status,
+                sessions.created_at AS session_created_at,
+                sessions.updated_at AS session_updated_at,
+                transcripts.id AS transcript_id,
+                transcripts.content,
+                transcripts.created_at AS transcript_created_at,
+                transcripts.updated_at AS transcript_updated_at
+            FROM sessions
+            LEFT JOIN transcripts
+                ON transcripts.session_id = sessions.id
+            WHERE sessions.id = ?
+            """,
+            (session_id,),
+        ).fetchone()
+    return _row_to_dict(row)
+
+
+def list_sessions(
+    *,
+    db_path: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    init_db(db_path)
+    with get_connection(db_path) as connection:
+        rows = connection.execute(
+            """
+            SELECT
+                sessions.id,
+                sessions.title,
+                sessions.original_filename,
+                sessions.stored_path,
+                sessions.status,
+                sessions.created_at,
+                sessions.updated_at,
+                transcripts.id IS NOT NULL AS has_transcript
+            FROM sessions
+            LEFT JOIN transcripts
+                ON transcripts.session_id = sessions.id
+            ORDER BY sessions.created_at DESC, sessions.id DESC
+            """
+        ).fetchall()
+    return [dict(row) for row in rows]

--- a/backend/forum_ai_notetaker/storage.py
+++ b/backend/forum_ai_notetaker/storage.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from typing import BinaryIO
+from uuid import uuid4
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_UPLOAD_ROOT = PROJECT_ROOT / "uploads"
+
+
+def resolve_upload_root(upload_root: str | Path | None = None) -> Path:
+    root = Path(upload_root) if upload_root is not None else DEFAULT_UPLOAD_ROOT
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _sanitize_filename(original_filename: str) -> tuple[str, str]:
+    filename = Path(original_filename or "upload").name
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "-", Path(filename).stem).strip("-._")
+    suffix = Path(filename).suffix.lower() or ".bin"
+    return (stem or "recording", suffix)
+
+
+def build_upload_path(
+    original_filename: str,
+    *,
+    session_id: int | None = None,
+    upload_root: str | Path | None = None,
+) -> Path:
+    root = resolve_upload_root(upload_root)
+    stem, suffix = _sanitize_filename(original_filename)
+    folder_name = str(session_id) if session_id is not None else "pending"
+    destination_dir = root / folder_name
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"{stem}-{uuid4().hex[:12]}{suffix}"
+    return destination_dir / filename
+
+
+def save_uploaded_file(
+    uploaded_file: BinaryIO | object,
+    *,
+    session_id: int | None = None,
+    upload_root: str | Path | None = None,
+) -> str:
+    original_filename = getattr(uploaded_file, "filename", None) or "upload"
+    destination = build_upload_path(
+        original_filename,
+        session_id=session_id,
+        upload_root=upload_root,
+    )
+
+    if hasattr(uploaded_file, "save"):
+        uploaded_file.save(destination)
+    else:
+        stream = getattr(uploaded_file, "stream", uploaded_file)
+        if hasattr(stream, "seek"):
+            stream.seek(0)
+        with destination.open("wb") as target:
+            shutil.copyfileobj(stream, target)
+
+    try:
+        return destination.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return destination.as_posix()


### PR DESCRIPTION
## What changed
- added repository helpers for `create_session()`, `save_transcript()`, `get_transcript()`, `list_sessions()`, and `get_session()`
- updated package exports so the helpers can be imported directly

## Why
This keeps database access in one place instead of scattering raw SQL through routes later.

## How to test
- initialize the sqlite database
- create a session
- save a transcript for that session
- fetch the transcript and list sessions