### PR TITLE
ci: run frontend lint on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  pull_request:
+
+jobs:
+  frontend-lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Run frontend lint
+        run: npm run lint


### PR DESCRIPTION
## What changed
- added a GitHub Actions workflow that installs frontend dependencies and runs ESLint on every pull request

## Why
This gives the repo a basic automated check before merge.

## How to test
- run `npm run lint` locally inside `frontend/`
- open any pull request and confirm the lint workflow runs