### PR TITLE
feat: add upload storage helper

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,44 @@
+# Backend Foundation
+
+This folder contains the Sprint 1 backend foundation for the database and storage layer.
+
+## What is included
+
+- SQLite schema for `sessions` and `transcripts`
+- Database helpers for creating sessions and storing transcripts
+- Upload storage helper that writes files into `./uploads/`
+- A tiny CLI entrypoint to initialize the local database
+
+## Quick start
+
+Initialize the local database:
+
+```bash
+python3 -m backend.forum_ai_notetaker
+```
+
+Example usage inside Flask routes or the processing pipeline:
+
+```python
+from backend.forum_ai_notetaker import (
+    create_session,
+    get_transcript,
+    init_db,
+    list_sessions,
+    save_transcript,
+    save_uploaded_file,
+)
+
+init_db()
+
+stored_path = save_uploaded_file(request.files["recording"])
+session = create_session(
+    title="Week 3 Forum",
+    original_filename=request.files["recording"].filename,
+    stored_path=stored_path,
+)
+
+save_transcript(session["id"], "Raw Whisper transcript text")
+sessions = list_sessions()
+transcript = get_transcript(session["id"])
+```

--- a/backend/forum_ai_notetaker/__init__.py
+++ b/backend/forum_ai_notetaker/__init__.py
@@ -8,13 +8,16 @@ from .repository import (
     list_sessions,
     save_transcript,
 )
+from .storage import DEFAULT_UPLOAD_ROOT, save_uploaded_file
 
 __all__ = [
     "DEFAULT_DB_PATH",
+    "DEFAULT_UPLOAD_ROOT",
     "create_session",
     "get_session",
     "get_transcript",
     "init_db",
     "list_sessions",
     "save_transcript",
+    "save_uploaded_file",
 ]

--- a/backend/forum_ai_notetaker/storage.py
+++ b/backend/forum_ai_notetaker/storage.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from typing import BinaryIO
+from uuid import uuid4
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_UPLOAD_ROOT = PROJECT_ROOT / "uploads"
+
+
+def resolve_upload_root(upload_root: str | Path | None = None) -> Path:
+    root = Path(upload_root) if upload_root is not None else DEFAULT_UPLOAD_ROOT
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _sanitize_filename(original_filename: str) -> tuple[str, str]:
+    filename = Path(original_filename or "upload").name
+    stem = re.sub(r"[^A-Za-z0-9._-]+", "-", Path(filename).stem).strip("-._")
+    suffix = Path(filename).suffix.lower() or ".bin"
+    return (stem or "recording", suffix)
+
+
+def build_upload_path(
+    original_filename: str,
+    *,
+    session_id: int | None = None,
+    upload_root: str | Path | None = None,
+) -> Path:
+    root = resolve_upload_root(upload_root)
+    stem, suffix = _sanitize_filename(original_filename)
+    folder_name = str(session_id) if session_id is not None else "pending"
+    destination_dir = root / folder_name
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"{stem}-{uuid4().hex[:12]}{suffix}"
+    return destination_dir / filename
+
+
+def save_uploaded_file(
+    uploaded_file: BinaryIO | object,
+    *,
+    session_id: int | None = None,
+    upload_root: str | Path | None = None,
+) -> str:
+    original_filename = getattr(uploaded_file, "filename", None) or "upload"
+    destination = build_upload_path(
+        original_filename,
+        session_id=session_id,
+        upload_root=upload_root,
+    )
+
+    if hasattr(uploaded_file, "save"):
+        uploaded_file.save(destination)
+    else:
+        stream = getattr(uploaded_file, "stream", uploaded_file)
+        if hasattr(stream, "seek"):
+            stream.seek(0)
+        with destination.open("wb") as target:
+            shutil.copyfileobj(stream, target)
+
+    try:
+        return destination.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return destination.as_posix()


### PR DESCRIPTION
## What changed
- added the upload storage helper that saves files into `./uploads/` with safe unique names
- added backend usage notes for the current helper flow
- updated exports so storage can be imported from the package directly

## Why
This standardizes how recordings are saved before the processing pipeline uses them.

## How to test
- save a mock upload with `save_uploaded_file()`
- confirm the file is written and the returned stored path is usable