### PR TITLE
feat: add backend sqlite foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+env/
+venv/
+.env
+
+data/*
+!data/.gitkeep
+uploads/*
+!uploads/.gitkeep
+
+*.db
+*.sqlite
+*.sqlite3

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for Forum AI Notetaker."""

--- a/backend/forum_ai_notetaker/__init__.py
+++ b/backend/forum_ai_notetaker/__init__.py
@@ -1,0 +1,5 @@
+"""Database helpers for Forum AI Notetaker."""
+
+from .db import DEFAULT_DB_PATH, init_db
+
+__all__ = ["DEFAULT_DB_PATH", "init_db"]

--- a/backend/forum_ai_notetaker/__main__.py
+++ b/backend/forum_ai_notetaker/__main__.py
@@ -1,0 +1,10 @@
+from .db import init_db
+
+
+def main() -> None:
+    db_path = init_db()
+    print(f"Initialized SQLite database at {db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/forum_ai_notetaker/db.py
+++ b/backend/forum_ai_notetaker/db.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "forum_ai_notetaker.sqlite3"
+SCHEMA_PATH = Path(__file__).with_name("schema.sql")
+
+
+def resolve_db_path(db_path: str | Path | None = None) -> Path:
+    path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def init_db(db_path: str | Path | None = None) -> Path:
+    path = resolve_db_path(db_path)
+    schema = SCHEMA_PATH.read_text(encoding="utf-8")
+    with sqlite3.connect(path) as connection:
+        connection.execute("PRAGMA foreign_keys = ON;")
+        connection.executescript(schema)
+    return path
+
+
+@contextmanager
+def get_connection(db_path: str | Path | None = None) -> Iterator[sqlite3.Connection]:
+    connection = sqlite3.connect(resolve_db_path(db_path))
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON;")
+    try:
+        yield connection
+    finally:
+        connection.close()

--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    original_filename TEXT NOT NULL,
+    stored_path TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL DEFAULT 'uploaded'
+        CHECK (status IN ('uploaded', 'processing', 'transcribed', 'failed')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS transcripts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id INTEGER NOT NULL UNIQUE,
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);

--- a/data/.gitkeep
+++ b/data/.gitkeep
@@ -1,0 +1,1 @@
+# Keeps the data directory in git while ignoring generated database files.

--- a/uploads/.gitkeep
+++ b/uploads/.gitkeep
@@ -1,0 +1,1 @@
+# Keeps the uploads directory in git while ignoring uploaded media files.


### PR DESCRIPTION
## What changed
- added the backend package scaffold and sqlite bootstrap entrypoint
- added the initial sqlite schema for `sessions` and `transcripts`
- ignored generated database and upload artifacts and kept their directories in git

## Why
This gives the backend a clean starting point for the rest of the data layer work.

## How to test
- run `python3 -m backend.forum_ai_notetaker`
- confirm the sqlite database initializes successfully