### PR TITLE
Wire real pipeline and SQLite into backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ uploads/*
 *.db
 *.sqlite
 *.sqlite3
+myenv

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ uploads/*
 *.sqlite
 *.sqlite3
 myenv
+
+# Test media files
+*.mp3
+*.mp4
+*.wav
+*.m4a

--- a/backend/app.py
+++ b/backend/app.py
@@ -17,6 +17,8 @@ to build a clean backend API that connects everything together.
 from flask import Flask
 from flask_cors import CORS
 
+from forum_ai_notetaker.db import init_db
+
 # Import route groups
 from routes.sessions import sessions_bp
 from routes.transcripts import transcripts_bp
@@ -36,6 +38,9 @@ def create_app():
     # Enable cross-origin requests so the React frontend
     # can communicate with the backend server.
     CORS(app)
+
+    # Create tables if they don't exist yet.
+    init_db()
 
     # Configuration
     # Uploaded recordings will be stored locally for now.

--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,8 @@ Those belong to other roles on the team. My responsibility is
 to build a clean backend API that connects everything together.
 """
 
+from pathlib import Path
+
 from flask import Flask
 from flask_cors import CORS
 
@@ -43,8 +45,12 @@ def create_app():
     init_db()
 
     # Configuration
-    # Uploaded recordings will be stored locally for now.
-    app.config["UPLOAD_FOLDER"] = "uploads"
+    # Resolve upload directory from backend root so it is stable
+    # regardless of the process working directory.
+    backend_root = Path(__file__).resolve().parent
+    upload_folder = backend_root / "uploads"
+    upload_folder.mkdir(parents=True, exist_ok=True)
+    app.config["UPLOAD_FOLDER"] = str(upload_folder)
 
     # Register API route groups
     app.register_blueprint(sessions_bp, url_prefix="/api/sessions")

--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     original_filename TEXT NOT NULL,
     stored_path TEXT NOT NULL UNIQUE,
     status TEXT NOT NULL DEFAULT 'uploaded'
-        CHECK (status IN ('uploaded', 'processing', 'transcribed', 'failed')),
+        CHECK (status IN ('uploaded', 'processing', 'transcribed', 'notes_generated', 'failed')),
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/backend/pipeline/__init__.py
+++ b/backend/pipeline/__init__.py
@@ -4,11 +4,5 @@ Pipeline package for Sprint 1 backend processing.
 
 from .audio import extract_audio
 from .transcribe import transcribe_audio
-from .process import process_recording
 
-__all__ = ["extract_audio", "transcribe_audio", "process_recording"]
-Pipeline package.
-
-This file can stay empty. The real point is that the backend has
-a clear place where the processing workflow is triggered.
-"""
+__all__ = ["extract_audio", "transcribe_audio"]

--- a/backend/pipeline/audio.py
+++ b/backend/pipeline/audio.py
@@ -34,8 +34,8 @@ def extract_audio(video_path: str) -> str:
     if not video_file.is_file():
         raise FileNotFoundError(f"Path is not a file: {video_file}")
 
-    # Save output in backend/uploads/audio to keep location predictable.
-    output_dir = Path("backend/uploads/audio").resolve()
+    # Save output in uploads/audio relative to this file's location.
+    output_dir = Path(__file__).resolve().parent.parent / "uploads" / "audio"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     output_audio = output_dir / f"{video_file.stem}.wav"

--- a/backend/pipeline/trigger.py
+++ b/backend/pipeline/trigger.py
@@ -1,42 +1,31 @@
 """
 Pipeline trigger.
 
-My role here is not to implement FFmpeg, Whisper, or Groq.
-My role is to make sure the backend has a clean entry point
-for the processing workflow after upload.
-
-Right now this is mocked so the entire backend can still be
-tested end-to-end during MVP 1.
+Entry point for the processing workflow after upload.
+Extracts audio with FFmpeg, transcribes with Whisper,
+and saves the transcript.
 """
 
+from pipeline.audio import extract_audio
+from pipeline.transcribe import transcribe_audio
 from services.session_service import update_session_status
 from services.transcript_service import save_transcript
-from services.note_service import save_notes
 
 
 def trigger_pipeline(file_path: str, session_id: int) -> None:
     """
     Trigger the processing workflow for an uploaded recording.
 
-    Current mocked flow:
-    upload -> processing -> transcript saved -> notes saved
+    Flow: upload -> extract audio -> transcribe -> save transcript
     """
 
-    # As soon as the backend hands the file off, the session
-    # should stop looking merely "uploaded" and start looking
-    # like it is actually being worked on.
     update_session_status(session_id, "processing")
 
-    # Placeholder transcript.
-    transcript_text = f"Mock transcript generated from {file_path}"
-
-    # Placeholder note output.
-    summary = "Mock summary for this lecture."
-    topics = ["Mock topic 1", "Mock topic 2"]
-    action_items = ["Mock action item 1", "Mock action item 2"]
-
-    save_transcript(session_id, transcript_text)
-    save_notes(session_id, summary, topics, action_items)
-
-    # Once everything is saved, we mark the session as done.
-    update_session_status(session_id, "notes_generated")
+    try:
+        audio_path = extract_audio(file_path)
+        transcript_text = transcribe_audio(audio_path)
+        save_transcript(session_id, transcript_text)
+        update_session_status(session_id, "transcribed")
+    except Exception as exc:
+        print(f"Pipeline failed for session {session_id}: {exc}")
+        update_session_status(session_id, "failed")

--- a/backend/pipeline/trigger.py
+++ b/backend/pipeline/trigger.py
@@ -6,10 +6,22 @@ Extracts audio with FFmpeg, transcribes with Whisper,
 and saves the transcript.
 """
 
+from pathlib import Path
+
 from pipeline.audio import extract_audio
 from pipeline.transcribe import transcribe_audio
 from services.session_service import update_session_status
 from services.transcript_service import save_transcript
+
+
+def _resolve_recording_path(file_path: str) -> str:
+    """Resolve a stored recording path to an absolute filesystem path."""
+    path = Path(file_path).expanduser()
+    if path.is_absolute():
+        return str(path.resolve())
+
+    backend_root = Path(__file__).resolve().parent.parent
+    return str((backend_root / path).resolve())
 
 
 def trigger_pipeline(file_path: str, session_id: int) -> None:
@@ -22,7 +34,8 @@ def trigger_pipeline(file_path: str, session_id: int) -> None:
     update_session_status(session_id, "processing")
 
     try:
-        audio_path = extract_audio(file_path)
+        absolute_recording_path = _resolve_recording_path(file_path)
+        audio_path = extract_audio(absolute_recording_path)
         transcript_text = transcribe_audio(audio_path)
         save_transcript(session_id, transcript_text)
         update_session_status(session_id, "transcribed")

--- a/backend/routes/sessions.py
+++ b/backend/routes/sessions.py
@@ -8,8 +8,8 @@ whole workflow. Once a recording enters here, the backend can
 store it, create a session record, and trigger the pipeline.
 """
 
-import os
 import uuid
+from pathlib import Path
 from flask import Blueprint, request, current_app
 
 from utils.responses import success_response, error_response
@@ -91,13 +91,18 @@ def upload_session():
 
     unique_filename = f"{uuid.uuid4().hex}{file_ext}"
 
-    upload_folder = current_app.config["UPLOAD_FOLDER"]
-    os.makedirs(upload_folder, exist_ok=True)
+    upload_folder = Path(
+        current_app.config["UPLOAD_FOLDER"]
+    ).expanduser().resolve()
+    upload_folder.mkdir(parents=True, exist_ok=True)
 
-    file_path = os.path.join(upload_folder, unique_filename)
+    file_path = upload_folder / unique_filename
 
     # Save the uploaded recording locally.
-    file.save(file_path)
+    file.save(str(file_path))
+
+    # Keep stored path backend-relative for portability.
+    recording_path = str(Path("uploads") / unique_filename)
 
     # Create a session record through the service layer.
     # We keep the original cleaned filename in the session metadata
@@ -105,13 +110,13 @@ def upload_session():
     session = create_session_record(
         title=title,
         filename=original_filename,
-        recording_path=file_path,
+        recording_path=recording_path,
         status="uploaded"
     )
 
     # Trigger the processing flow.
     # The internal pipeline is still not my responsibility,
     # but the backend should still provide the entry point for it.
-    trigger_pipeline(file_path, session["id"])
+    trigger_pipeline(recording_path, session["id"])
 
     return success_response("Recording uploaded successfully", session, 201)

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -1,64 +1,49 @@
 """
 Session service layer.
 
-This file acts as the boundary between the backend API layer
-and the eventual database layer.
-
-For now I am using in-memory placeholder storage so the backend
-can actually run and be tested before full DB integration is done.
-That way the routes are already stable and the DB teammate can
-later replace the internals without forcing a rewrite of my API code.
+Connects the backend API to the SQLite database.
 """
 
+from datetime import datetime, timezone
 from typing import Optional
 
-SESSIONS = []
-NEXT_SESSION_ID = 1
+from forum_ai_notetaker.db import get_connection
+
+
+def _row_to_dict(row) -> dict:
+    return dict(row)
 
 
 def create_session_record(title: str, filename: str, recording_path: str, status: str) -> dict:
-    """
-    Create a new session record.
-
-    For now this stores data in memory.
-    Later this function should be replaced with real DB logic.
-    """
-    global NEXT_SESSION_ID
-
-    session = {
-        "id": NEXT_SESSION_ID,
-        "title": title,
-        "filename": filename,
-        "recording_path": recording_path,
-        "status": status
-    }
-
-    SESSIONS.append(session)
-    NEXT_SESSION_ID += 1
-    return session
+    now = datetime.now(timezone.utc).isoformat()
+    with get_connection() as conn:
+        cursor = conn.execute(
+            "INSERT INTO sessions (title, original_filename, stored_path, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (title, filename, recording_path, status, now, now),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM sessions WHERE id = ?", (cursor.lastrowid,)).fetchone()
+    return _row_to_dict(row)
 
 
 def fetch_all_sessions() -> list[dict]:
-    """
-    Return all sessions.
-    """
-    return SESSIONS
+    with get_connection() as conn:
+        rows = conn.execute("SELECT * FROM sessions ORDER BY created_at DESC").fetchall()
+    return [_row_to_dict(r) for r in rows]
 
 
 def fetch_one_session(session_id: int) -> Optional[dict]:
-    """
-    Return one session by ID.
-    """
-    return next((session for session in SESSIONS if session["id"] == session_id), None)
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+    return _row_to_dict(row) if row else None
 
 
 def update_session_status(session_id: int, new_status: str) -> None:
-    """
-    Update the status of a session.
-
-    This matters because the frontend dashboard needs to know
-    what stage of the workflow a session is currently in.
-    """
-    session = fetch_one_session(session_id)
-    if session:
-        session["status"] = new_status
+    now = datetime.now(timezone.utc).isoformat()
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?",
+            (new_status, now, session_id),
+        )
+        conn.commit()

--- a/backend/services/transcript_service.py
+++ b/backend/services/transcript_service.py
@@ -1,27 +1,29 @@
 """
 Transcript service layer.
 
-Like the session service, this is a placeholder interface that
-keeps the backend routes stable even before full DB integration.
+Connects the backend API to the SQLite database.
 """
 
+from datetime import datetime, timezone
 from typing import Optional
 
-TRANSCRIPTS = {}
+from forum_ai_notetaker.db import get_connection
 
 
 def save_transcript(session_id: int, transcript_text: str) -> None:
-    """
-    Save transcript data for a session.
-    """
-    TRANSCRIPTS[session_id] = {
-        "session_id": session_id,
-        "text": transcript_text
-    }
+    now = datetime.now(timezone.utc).isoformat()
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO transcripts (session_id, content, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?)",
+            (session_id, transcript_text, now, now),
+        )
+        conn.commit()
 
 
 def fetch_transcript_by_session_id(session_id: int) -> Optional[dict]:
-    """
-    Return transcript data for a session if it exists.
-    """
-    return TRANSCRIPTS.get(session_id)
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT * FROM transcripts WHERE session_id = ?", (session_id,)
+        ).fetchone()
+    return dict(row) if row else None

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -55,6 +55,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1429,6 +1430,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1470,6 +1472,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1578,6 +1581,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1812,6 +1816,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2498,6 +2503,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2559,6 +2565,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2568,6 +2575,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2836,6 +2844,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2957,6 +2966,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- Replaced mock pipeline with real FFmpeg audio extraction + Whisper transcription in `trigger.py`
- Wired `session_service` and `transcript_service` to SQLite instead of in-memory storage
- Auto-initialize database on app startup
- Fixed audio output path to work regardless of working directory
- Added `notes_generated` to session status constraint

## Test plan
- [ ] Uploaded `test.mp3` → transcription returned: *"Hi, this is the Test MP3. If you see this, your code is working."*
- [ ] Test with a longer recording to verify Whisper handles real lectures
- [ ] Verify data persists across server restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)