### PR TITLE
feat: add users table to schema

### DIFF
--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -1,3 +1,14 @@
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
 CREATE TABLE IF NOT EXISTS sessions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT NOT NULL,


### PR DESCRIPTION
## what changed
- added a `users` table to the sqlite schema
- added a unique index on `users.email`

## why
this sets up the base user record storage the backend auth flow will need.

## how to test
- run `python3 -m backend.forum_ai_notetaker`
- confirm the sqlite database initializes with a `users` table