### PR TITLE
feat: rewrite note service to use sqlite

### DIFF
--- a/backend/services/note_service.py
+++ b/backend/services/note_service.py
@@ -1,29 +1,66 @@
 """
 Notes service layer.
 
-This stores and returns generated notes. Again, this is mocked
-in memory for now so the full backend flow can be tested early.
+Connects generated notes to the SQLite database.
 """
 
+import json
+from datetime import datetime, timezone
 from typing import Optional
 
-NOTES = {}
+from forum_ai_notetaker.db import get_connection
+
+
+def _row_to_dict(row) -> dict:
+    return {
+        "id": row["id"],
+        "session_id": row["session_id"],
+        "summary": row["summary"],
+        "topics": json.loads(row["topics"]),
+        "action_items": json.loads(row["action_items"]),
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
 
 
 def save_notes(session_id: int, summary: str, topics: list[str], action_items: list[str]) -> None:
     """
     Save generated notes for a session.
     """
-    NOTES[session_id] = {
-        "session_id": session_id,
-        "summary": summary,
-        "topics": topics,
-        "action_items": action_items
-    }
+    now = datetime.now(timezone.utc).isoformat()
+    encoded_topics = json.dumps(topics)
+    encoded_action_items = json.dumps(action_items)
+
+    with get_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO notes (session_id, summary, topics, action_items, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                summary = excluded.summary,
+                topics = excluded.topics,
+                action_items = excluded.action_items,
+                updated_at = excluded.updated_at
+            """,
+            (session_id, summary, encoded_topics, encoded_action_items, now, now),
+        )
+        conn.commit()
+
+
+def get_notes_by_session(session_id: int) -> Optional[dict]:
+    """
+    Return generated notes for a session if they exist.
+    """
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT * FROM notes WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+    return _row_to_dict(row) if row else None
 
 
 def fetch_notes_by_session_id(session_id: int) -> Optional[dict]:
     """
-    Return generated notes for a session if they exist.
+    Backward-compatible wrapper used by the existing notes route.
     """
-    return NOTES.get(session_id)
+    return get_notes_by_session(session_id)


### PR DESCRIPTION
## what changed
- rewrote `note_service.py` to save notes in sqlite instead of in-memory storage
- added `get_notes_by_session()`
- kept `fetch_notes_by_session_id()` as a compatibility wrapper for the current route

## why
generated notes need to persist across restarts and match the rest of the backend data layer.

## how to test
- initialize the database
- create a session row
- call `save_notes()` and then `get_notes_by_session()`
- confirm the saved notes are returned from sqlite