### PR TITLE
feat: add course_members table to schema

### DIFF
--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -19,6 +19,22 @@ CREATE TABLE IF NOT EXISTS courses (
 
 CREATE INDEX IF NOT EXISTS idx_courses_invite_code ON courses(invite_code);
 
+CREATE TABLE IF NOT EXISTS course_members (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    course_id INTEGER NOT NULL,
+    user_id INTEGER NOT NULL,
+    role TEXT NOT NULL DEFAULT 'student'
+        CHECK (role IN ('student', 'ta', 'instructor')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (course_id, user_id),
+    FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_course_members_course_id ON course_members(course_id);
+CREATE INDEX IF NOT EXISTS idx_course_members_user_id ON course_members(user_id);
+
 CREATE TABLE IF NOT EXISTS sessions (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT NOT NULL,


### PR DESCRIPTION
## what changed
- added a `course_members` join table to the sqlite schema
- added foreign keys to `courses` and `users`
- added indexes for `course_id` and `user_id`

## why
this sets up membership tracking between users and courses.

## how to test
- run `python3 -m backend.forum_ai_notetaker`
- confirm the sqlite database initializes with a `course_members` table
- confirm the table enforces the course/user relationship