### PR TITLE
ci: require PRs to target main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Checklist
+
+- [ ] This PR targets `main`.
+- [ ] I checked that this PR does not accidentally target another feature branch.
+- [ ] I ran or reviewed the relevant checks for this change.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
 
 jobs:
+  validate-pr-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require pull requests to target main
+        run: |
+          if [ "${{ github.base_ref }}" != "main" ]; then
+            echo "::error::Pull requests must target main. Current base is '${{ github.base_ref }}'."
+            exit 1
+          fi
+
   frontend-lint:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
Adds a CI guard that fails pull requests targeting any branch other than main, plus a PR template reminder so reviewers can catch the base branch before merging.