### PR TITLE
Add login/register and JWT auth wiring

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,13 @@
-import Router from "./router";
+import AppRouter from "./router";
 import Navbar from "./components/Navbar";
+import AuthProvider from "./contexts/AuthContext";
 
 function App() {
   return (
-    <>
+    <AuthProvider>
       <Navbar />
-      <Router />
-    </>
+      <AppRouter />
+    </AuthProvider>
   );
 }
 

--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -1,9 +1,27 @@
 // Use an env override when needed; otherwise rely on Vite proxy (/api -> backend).
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
 
+function getToken() {
+  return localStorage.getItem("token");
+}
+
 async function request(path, options = {}) {
   // Central request helper so all endpoints share one error-handling pattern.
-  const response = await fetch(`${API_BASE}${path}`, options);
+  const headers = { ...options.headers };
+  const token = getToken();
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_BASE}${path}`, { ...options, headers });
+
+  // If the server says 401, the token is bad or expired — clear it and let
+  // the caller handle the redirect (ProtectedRoute will kick to /login).
+  if (response.status === 401) {
+    localStorage.removeItem("token");
+    throw new Error("Session expired. Please log in again.");
+  }
+
   const rawText = await response.text();
   let payload = null;
 
@@ -23,6 +41,30 @@ async function request(path, options = {}) {
   return payload;
 }
 
+// --- Auth ---
+
+export function loginUser(email, password) {
+  return request("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+export function registerUser(name, email, password) {
+  return request("/api/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, email, password }),
+  });
+}
+
+export function getMe() {
+  return request("/api/auth/me");
+}
+
+// --- Sessions ---
+
 export function getSessions() {
   return request("/api/sessions");
 }
@@ -39,9 +81,13 @@ export function uploadSession({ title, file }) {
   });
 }
 
+// --- Transcripts ---
+
 export function getTranscript(sessionId) {
   return request(`/api/transcripts/${sessionId}`);
 }
+
+// --- Notes ---
 
 export function getNotes(sessionId) {
   return request(`/api/notes/session/${sessionId}`);

--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -19,6 +19,7 @@ async function request(path, options = {}) {
   // the caller handle the redirect (ProtectedRoute will kick to /login).
   if (response.status === 401) {
     localStorage.removeItem("token");
+    window.dispatchEvent(new CustomEvent("auth:expired"));
     throw new Error("Session expired. Please log in again.");
   }
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,12 +1,37 @@
 import { Link } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
 
 export default function Navbar() {
+  const { user, logout } = useAuth();
+
   return (
     <nav>
-      <Link to="/">Dashboard</Link>
-      <Link to="/upload">Upload</Link>
-      <Link to="/search">Search</Link>
-      <Link to="/login">Login</Link>
+      <div className="nav-links">
+        {user ? (
+          <>
+            <Link to="/">Dashboard</Link>
+            <Link to="/upload">Upload</Link>
+            <Link to="/search">Search</Link>
+          </>
+        ) : (
+          <Link to="/login">Forum AI Notetaker</Link>
+        )}
+      </div>
+
+      <div className="nav-user">
+        {user ? (
+          <>
+            <span className="nav-greeting">
+              Hey, {user.name || user.email}
+            </span>
+            <button className="nav-logout" onClick={logout}>
+              Log out
+            </button>
+          </>
+        ) : (
+          <Link to="/login">Log in</Link>
+        )}
+      </div>
     </nav>
   );
 }

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
+import useAuth from "../hooks/useAuth";
 
 export default function Navbar() {
   const { user, logout } = useAuth();

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,20 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+
+export default function ProtectedRoute({ children }) {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="container">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+}

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,5 +1,5 @@
 import { Navigate } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
+import useAuth from "../hooks/useAuth";
 
 export default function ProtectedRoute({ children }) {
   const { user, loading } = useAuth();

--- a/frontend/src/components/PublicOnlyRoute.jsx
+++ b/frontend/src/components/PublicOnlyRoute.jsx
@@ -1,5 +1,5 @@
 import { Navigate } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
+import useAuth from "../hooks/useAuth";
 
 export default function PublicOnlyRoute({ children }) {
   const { user, loading } = useAuth();

--- a/frontend/src/components/PublicOnlyRoute.jsx
+++ b/frontend/src/components/PublicOnlyRoute.jsx
@@ -1,0 +1,16 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../contexts/AuthContext";
+
+export default function PublicOnlyRoute({ children }) {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return null;
+  }
+
+  if (user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+}

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,7 +1,6 @@
-import { createContext, useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { loginUser, registerUser, getMe } from "../api/backend";
-
-export const AuthContext = createContext(null);
+import { AuthContext } from "./auth-context";
 
 export default function AuthProvider({ children }) {
   const hasToken = Boolean(localStorage.getItem("token"));

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback } from "react";
+import { createContext, useState, useEffect, useCallback } from "react";
 import { loginUser, registerUser, getMe } from "../api/backend";
-import AuthContext from "./authContext";
+
+export const AuthContext = createContext(null);
 
 export default function AuthProvider({ children }) {
   const hasToken = Boolean(localStorage.getItem("token"));
@@ -46,6 +47,11 @@ export default function AuthProvider({ children }) {
     localStorage.removeItem("token");
     setUser(null);
   }, []);
+
+  useEffect(() => {
+    window.addEventListener("auth:expired", logout);
+    return () => window.removeEventListener("auth:expired", logout);
+  }, [logout]);
 
   return (
     <AuthContext.Provider value={{ user, loading, login, register, logout }}>

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,0 +1,66 @@
+import { createContext, useContext, useState, useEffect, useCallback } from "react";
+import { loginUser, registerUser, getMe } from "../api/backend";
+
+const AuthContext = createContext(null);
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used inside AuthProvider");
+  }
+  return ctx;
+}
+
+export default function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+
+    getMe()
+      .then((payload) => {
+        if (!cancelled) setUser(payload.data);
+      })
+      .catch(() => {
+        if (!cancelled) localStorage.removeItem("token");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const login = useCallback(async (email, password) => {
+    const payload = await loginUser(email, password);
+    localStorage.setItem("token", payload.data.token);
+    setUser(payload.data.user);
+    return payload;
+  }, []);
+
+  const register = useCallback(async (name, email, password) => {
+    const payload = await registerUser(name, email, password);
+    localStorage.setItem("token", payload.data.token);
+    setUser(payload.data.user);
+    return payload;
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem("token");
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,7 +1,6 @@
-import { createContext, useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { loginUser, registerUser, getMe } from "../api/backend";
-
-export const AuthContext = createContext(null);
+import AuthContext from "./authContext";
 
 export default function AuthProvider({ children }) {
   const hasToken = Boolean(localStorage.getItem("token"));

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,27 +1,17 @@
-import { createContext, useContext, useState, useEffect, useCallback } from "react";
+import { createContext, useState, useEffect, useCallback } from "react";
 import { loginUser, registerUser, getMe } from "../api/backend";
 
-const AuthContext = createContext(null);
-
-export function useAuth() {
-  const ctx = useContext(AuthContext);
-  if (!ctx) {
-    throw new Error("useAuth must be used inside AuthProvider");
-  }
-  return ctx;
-}
+export const AuthContext = createContext(null);
 
 export default function AuthProvider({ children }) {
+  const hasToken = Boolean(localStorage.getItem("token"));
   const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(hasToken);
 
   useEffect(() => {
+    if (!hasToken) return;
+
     let cancelled = false;
-    const token = localStorage.getItem("token");
-    if (!token) {
-      setLoading(false);
-      return;
-    }
 
     getMe()
       .then((payload) => {
@@ -37,7 +27,7 @@ export default function AuthProvider({ children }) {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [hasToken]);
 
   const login = useCallback(async (email, password) => {
     const payload = await loginUser(email, password);

--- a/frontend/src/contexts/auth-context.js
+++ b/frontend/src/contexts/auth-context.js
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const AuthContext = createContext(null);

--- a/frontend/src/contexts/authContext.js
+++ b/frontend/src/contexts/authContext.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const AuthContext = createContext(null);
+
+export default AuthContext;

--- a/frontend/src/contexts/authContext.js
+++ b/frontend/src/contexts/authContext.js
@@ -1,5 +1,0 @@
-import { createContext } from "react";
-
-const AuthContext = createContext(null);
-
-export default AuthContext;

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { AuthContext } from "../contexts/AuthContext.jsx";
+import { AuthContext } from "../contexts/auth-context";
 
 export default function useAuth() {
   const ctx = useContext(AuthContext);

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import AuthContext from "../contexts/authContext";
+import { AuthContext } from "../contexts/AuthContext.jsx";
 
 export default function useAuth() {
   const ctx = useContext(AuthContext);

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { AuthContext } from "../contexts/AuthContext";
+
+export default function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used inside AuthProvider");
+  }
+  return ctx;
+}

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { AuthContext } from "../contexts/AuthContext";
+import AuthContext from "../contexts/authContext";
 
 export default function useAuth() {
   const ctx = useContext(AuthContext);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,31 +1,183 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   font-family: system-ui, -apple-system, Arial, sans-serif;
   margin: 0;
   background-color: #f8f9fb;
 }
 
+/* --- Nav --- */
+
 nav {
   display: flex;
-  gap: 20px;
+  justify-content: space-between;
+  align-items: center;
   padding: 16px 24px;
   background-color: #1e293b;
 }
 
-nav a {
+.nav-links {
+  display: flex;
+  gap: 20px;
+}
+
+.nav-links a,
+.nav-user a {
   color: white;
   text-decoration: none;
   font-weight: 500;
 }
 
-nav a:hover {
+.nav-links a:hover,
+.nav-user a:hover {
   text-decoration: underline;
 }
+
+.nav-user {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.nav-greeting {
+  color: #94a3b8;
+  font-size: 14px;
+}
+
+.nav-logout {
+  background: none;
+  border: none;
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0;
+}
+
+.nav-logout:hover {
+  color: white;
+}
+
+/* --- Layout --- */
 
 .container {
   max-width: 900px;
   margin: auto;
   padding: 32px;
 }
+
+/* --- Buttons --- */
+
+button {
+  padding: 10px 18px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: #2563eb;
+  color: white;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #1d4ed8;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: white;
+  color: #374151;
+  border: 1px solid #cbd5e1;
+}
+
+.btn-secondary:hover {
+  background: #f1f5f9;
+}
+
+/* --- Auth pages --- */
+
+.auth-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 56px);
+  padding: 32px;
+}
+
+.auth-card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 32px;
+  width: 100%;
+  max-width: 400px;
+}
+
+.auth-card h1 {
+  margin: 0 0 24px;
+  font-size: 22px;
+}
+
+.auth-form {
+  display: grid;
+  gap: 16px;
+}
+
+.form-field {
+  display: grid;
+  gap: 6px;
+}
+
+.form-field label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+}
+
+.form-field input {
+  padding: 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.form-field input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
+}
+
+.form-field input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: #f1f5f9;
+}
+
+.auth-footer {
+  margin-top: 20px;
+  text-align: center;
+  font-size: 14px;
+  color: #64748b;
+}
+
+.auth-footer a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.auth-footer a:hover {
+  text-decoration: underline;
+}
+
+/* --- Dashboard --- */
 
 .dashboard-header {
   display: flex;
@@ -67,13 +219,13 @@ nav a:hover {
 }
 
 .dashboard-toolbar input,
-.dashboard-toolbar select,
-.upload-form input,
-.upload-form button {
+.dashboard-toolbar select {
   padding: 10px;
   border: 1px solid #cbd5e1;
   border-radius: 8px;
 }
+
+/* --- Session list --- */
 
 .session-list {
   list-style: none;
@@ -93,10 +245,19 @@ nav a:hover {
   gap: 12px;
 }
 
+/* --- Upload --- */
+
 .upload-form {
   display: grid;
   gap: 14px;
   text-align: left;
+}
+
+.upload-form input,
+.upload-form select {
+  padding: 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
 }
 
 .upload-dropzone {
@@ -111,6 +272,8 @@ nav a:hover {
   background: #eff6ff;
 }
 
+/* --- Utility --- */
+
 .muted-text {
   color: #64748b;
   font-size: 14px;
@@ -123,6 +286,7 @@ nav a:hover {
 }
 
 .error-text {
-  margin-top: 12px;
+  margin-top: 0;
   color: #b91c1c;
+  font-size: 14px;
 }

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
+import useAuth from "../hooks/useAuth";
 
 export default function Login() {
   const { login } = useAuth();

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
+import useAuth from "../hooks/useAuth";
 
 export default function Register() {
   const { register } = useAuth();

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -2,12 +2,14 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../contexts/AuthContext";
 
-export default function Login() {
-  const { login } = useAuth();
+export default function Register() {
+  const { register } = useAuth();
   const navigate = useNavigate();
 
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -15,21 +17,29 @@ export default function Login() {
     e.preventDefault();
     setError("");
 
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
     if (!email.trim()) {
       setError("Email is required.");
       return;
     }
-    if (!password) {
-      setError("Password is required.");
+    if (password.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords don't match.");
       return;
     }
 
     setLoading(true);
     try {
-      await login(email.trim().toLowerCase(), password);
+      await register(name.trim(), email.trim().toLowerCase(), password);
       navigate("/", { replace: true });
     } catch (err) {
-      setError(err.message || "Login failed.");
+      setError(err.message || "Registration failed.");
     } finally {
       setLoading(false);
     }
@@ -38,9 +48,22 @@ export default function Login() {
   return (
     <div className="auth-page">
       <div className="auth-card">
-        <h1>Log in</h1>
+        <h1>Create account</h1>
 
         <form className="auth-form" onSubmit={handleSubmit}>
+          <div className="form-field">
+            <label htmlFor="name">Name</label>
+            <input
+              id="name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+              disabled={loading}
+              autoComplete="name"
+            />
+          </div>
+
           <div className="form-field">
             <label htmlFor="email">Email</label>
             <input
@@ -61,21 +84,34 @@ export default function Login() {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="Your password"
+              placeholder="At least 8 characters"
               disabled={loading}
-              autoComplete="current-password"
+              autoComplete="new-password"
+            />
+          </div>
+
+          <div className="form-field">
+            <label htmlFor="confirm-password">Confirm password</label>
+            <input
+              id="confirm-password"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="Same password again"
+              disabled={loading}
+              autoComplete="new-password"
             />
           </div>
 
           {error ? <p className="error-text" role="alert">{error}</p> : null}
 
           <button type="submit" disabled={loading}>
-            {loading ? "Logging in..." : "Log in"}
+            {loading ? "Creating account..." : "Create account"}
           </button>
         </form>
 
         <p className="auth-footer">
-          Don&apos;t have an account? <Link to="/register">Sign up</Link>
+          Already have an account? <Link to="/login">Log in</Link>
         </p>
       </div>
     </div>

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -1,19 +1,68 @@
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 
 import Dashboard from "./pages/Dashboard";
 import Upload from "./pages/Upload";
 import Notes from "./pages/Notes";
 import Search from "./pages/Search";
 import Login from "./pages/Login";
+import Register from "./pages/Register";
+import ProtectedRoute from "./components/ProtectedRoute";
+import PublicOnlyRoute from "./components/PublicOnlyRoute";
 
-export default function Router() {
+export default function AppRouter() {
   return (
-      <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/upload" element={<Upload />} />
-        <Route path="/notes/:id" element={<Notes />} />
-        <Route path="/search" element={<Search />} />
-        <Route path="/login" element={<Login />} />
-      </Routes>
+    <Routes>
+      <Route
+        path="/login"
+        element={
+          <PublicOnlyRoute>
+            <Login />
+          </PublicOnlyRoute>
+        }
+      />
+      <Route
+        path="/register"
+        element={
+          <PublicOnlyRoute>
+            <Register />
+          </PublicOnlyRoute>
+        }
+      />
+
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <Dashboard />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/upload"
+        element={
+          <ProtectedRoute>
+            <Upload />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/notes/:id"
+        element={
+          <ProtectedRoute>
+            <Notes />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/search"
+        element={
+          <ProtectedRoute>
+            <Search />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
   );
 }


### PR DESCRIPTION
## What changed
- Built login and register pages (replaced the login stub)
- Added AuthContext for JWT persistence in localStorage
- API client attaches Bearer token to all requests, clears token on 401
- Protected routes redirect to /login when unauthenticated
- Public routes (/login, /register) redirect to dashboard when already authenticated
- Navbar shows user greeting + logout when logged in, hides protected links when logged out
- Added base button styles and box-sizing reset

## New files
- `src/contexts/AuthContext.jsx` — auth state provider, token management, /me fetch on mount
- `src/components/ProtectedRoute.jsx` — guards authenticated pages
- `src/components/PublicOnlyRoute.jsx` — guards login/register from logged-in users
- `src/pages/Register.jsx` — registration form with validation

## Modified files
- `src/pages/Login.jsx` — full form replacing stub
- `src/api/backend.js` — auth header injection, 401 handling, auth API functions
- `src/router.jsx` — route guards, /register route, catch-all redirect
- `src/App.jsx` — wrapped in AuthProvider
- `src/components/Navbar.jsx` — conditional nav links, user area with logout
- `src/index.css` — auth page styles, button base, navbar layout, box-sizing reset

## How to test
1. Visit / while logged out → redirects to /login
2. Register a new account → redirects to dashboard
3. Refresh page → stays logged in (token persisted)
4. Log out → redirects to /login, nav links hidden
5. Log in with wrong password → inline error message
6. Visit /login while logged in → redirects to dashboard
7. Clear localStorage manually, refresh → redirects to /login