### PR TITLE
Add course creation, invite code join, and require_auth decorator

### DIFF
--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -64,6 +64,32 @@ export function getMe() {
   return request("/api/auth/me");
 }
 
+// --- Courses ---
+
+export function createCourse(name) {
+  return request("/api/courses/", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+}
+
+export function joinCourse(inviteCode) {
+  return request("/api/courses/join", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ invite_code: inviteCode }),
+  });
+}
+
+export function getCourses() {
+  return request("/api/courses/");
+}
+
+export function getCourse(courseId) {
+  return request(`/api/courses/${courseId}`);
+}
+
 // --- Sessions ---
 
 export function getSessions() {

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -10,6 +10,8 @@ export default function Navbar() {
         {user ? (
           <>
             <Link to="/">Dashboard</Link>
+            <Link to="/courses/create">Create Course</Link>
+            <Link to="/courses/join">Join Course</Link>
             <Link to="/upload">Upload</Link>
             <Link to="/search">Search</Link>
           </>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -160,6 +160,55 @@ button:disabled {
   background-color: #f1f5f9;
 }
 
+/* --- Invite code --- */
+
+.invite-code-display {
+  font-family: "Courier New", monospace;
+  font-size: 18px;
+  letter-spacing: 0.15em;
+  text-align: center;
+  padding: 12px 16px;
+  background: #f1f5f9;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  margin-top: 4px;
+}
+
+.invite-code-input {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-family: "Courier New", monospace;
+}
+
+.invite-code-label {
+  margin-top: 20px;
+  margin-bottom: 8px;
+  font-size: 14px;
+  color: #374151;
+}
+
+.invite-code-copy {
+  margin-top: 12px;
+}
+
+.course-success-card {
+  text-align: center;
+}
+
+.course-success-link {
+  margin-top: 20px;
+}
+
+.course-success-link a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.course-success-link a:hover {
+  text-decoration: underline;
+}
+
 .auth-footer {
   margin-top: 20px;
   text-align: center;

--- a/frontend/src/pages/CreateCourse.jsx
+++ b/frontend/src/pages/CreateCourse.jsx
@@ -1,0 +1,106 @@
+import { useState, useRef, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { createCourse } from "../api/backend";
+
+export default function CreateCourse() {
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [createdCourse, setCreatedCourse] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (loading) return;
+    setError("");
+
+    if (!name.trim()) {
+      setError("Course name is required.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const payload = await createCourse(name.trim());
+      setCreatedCourse(payload.data);
+    } catch (err) {
+      setError(err.message || "Failed to create course.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleCopy() {
+    if (!createdCourse) return;
+    navigator.clipboard.writeText(createdCourse.invite_code).catch(() => {});
+    setCopied(true);
+    timerRef.current = setTimeout(() => setCopied(false), 2000);
+  }
+
+  if (createdCourse) {
+    return (
+      <div className="auth-page">
+        <div className="auth-card course-success-card">
+          <h1>Course created</h1>
+          <p className="muted-text">{createdCourse.name}</p>
+
+          <p className="invite-code-label">
+            Share this invite code with your students:
+          </p>
+
+          <div className="invite-code-display" aria-label="Invite code">
+            {createdCourse.invite_code}
+          </div>
+
+          <button
+            className="btn-secondary invite-code-copy"
+            onClick={handleCopy}
+            aria-live="polite"
+          >
+            {copied ? "Copied!" : "Copy code"}
+          </button>
+
+          <p className="course-success-link">
+            <Link to="/">Go to Dashboard</Link>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        <h1>Create course</h1>
+
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <div className="form-field">
+            <label htmlFor="course-name">Course name</label>
+            <input
+              id="course-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. CS 101 — Intro to Computer Science"
+              disabled={loading}
+              autoComplete="off"
+            />
+          </div>
+
+          {error ? <p className="error-text" role="alert">{error}</p> : null}
+
+          <button type="submit" disabled={loading}>
+            {loading ? "Creating..." : "Create course"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/JoinCourse.jsx
+++ b/frontend/src/pages/JoinCourse.jsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { joinCourse } from "../api/backend";
+
+export default function JoinCourse() {
+  const navigate = useNavigate();
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (loading) return;
+    setError("");
+
+    if (!code.trim()) {
+      setError("Invite code is required.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await joinCourse(code.trim());
+      navigate("/", { replace: true });
+    } catch (err) {
+      setError(err.message || "Failed to join course.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="auth-page">
+      <div className="auth-card">
+        <h1>Join course</h1>
+
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <div className="form-field">
+            <label htmlFor="invite-code">Invite code</label>
+            <input
+              id="invite-code"
+              type="text"
+              className="invite-code-input"
+              value={code}
+              onChange={(e) => {
+                setCode(e.target.value.toUpperCase());
+                setError("");
+              }}
+              placeholder="e.g. A1B2C3D4E5F6"
+              disabled={loading}
+              autoComplete="off"
+            />
+          </div>
+
+          {error ? <p className="error-text" role="alert">{error}</p> : null}
+
+          <button type="submit" disabled={loading}>
+            {loading ? "Joining..." : "Join course"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -4,6 +4,8 @@ import Dashboard from "./pages/Dashboard";
 import Upload from "./pages/Upload";
 import Notes from "./pages/Notes";
 import Search from "./pages/Search";
+import CreateCourse from "./pages/CreateCourse";
+import JoinCourse from "./pages/JoinCourse";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
 import ProtectedRoute from "./components/ProtectedRoute";
@@ -50,6 +52,22 @@ export default function AppRouter() {
         element={
           <ProtectedRoute>
             <Notes />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/courses/create"
+        element={
+          <ProtectedRoute>
+            <CreateCourse />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/courses/join"
+        element={
+          <ProtectedRoute>
+            <JoinCourse />
           </ProtectedRoute>
         }
       />


### PR DESCRIPTION
## What changed

### Backend
- Added `require_auth` decorator to `utils/auth.py` that extracts JWT, verifies it, and attaches user to `flask.g`
- New `services/course_service.py` with course creation (atomic with instructor membership), join by invite code, list user courses, get course detail/members, membership checks
- New `routes/courses.py` with `POST /`, `POST /join`, `GET /`, `GET /<id>` (all require auth, detail checks membership)
- Invite codes are 12-char hex strings (48-bit entropy), retry on collision
- Detail endpoint strips invite_code from response for students (only visible to instructor/TA)
- Registered courses blueprint in `app.py`

### Frontend
- Create Course page (`/courses/create`) with name input form, success state shows invite code with copy-to-clipboard
- Join Course page (`/courses/join`) with uppercase monospace code input, redirects to dashboard on success
- Added course API functions to `backend.js`
- Updated router with protected routes for both pages
- Updated navbar with Create Course and Join Course links

## New files
- `backend/services/course_service.py`
- `backend/routes/courses.py`
- `frontend/src/pages/CreateCourse.jsx`
- `frontend/src/pages/JoinCourse.jsx`

## Modified files
- `backend/utils/auth.py` - added `require_auth` decorator
- `backend/app.py` - registered courses blueprint
- `frontend/src/api/backend.js` - course API functions
- `frontend/src/router.jsx` - course routes
- `frontend/src/components/Navbar.jsx` - course nav links
- `frontend/src/index.css` - invite code display/input styles, success card styles

## How to test
1. Register two accounts (A and B)
2. Account A: go to Create Course, enter a name, submit. Should see invite code with copy button
3. Click "Copy code". Should show "Copied!" for 2 seconds
4. Account B: go to Join Course, paste the code, submit. Should redirect to dashboard
5. Try joining with a bad code. Should show error
6. Try joining the same course again. Should show "already a member" error
7. Try creating a course with no name. Should show validation error
8. `GET /api/courses/` with auth header. Should return both users' courses with their roles