### PR TITLE
Add course selector to upload and status-aware notes page

### DIFF
--- a/backend/routes/sessions.py
+++ b/backend/routes/sessions.py
@@ -23,6 +23,7 @@ from services.session_service import (
     create_session_record,
     fetch_sessions_for_user,
     fetch_one_session,
+    search_sessions_for_user,
 )
 from services.course_service import get_course_by_id, is_course_member, is_ta_or_professor
 from pipeline.trigger import trigger_pipeline
@@ -38,6 +39,21 @@ def get_sessions():
     """
     sessions = fetch_sessions_for_user(g.user["id"])
     return success_response("Sessions retrieved successfully", sessions)
+
+
+@sessions_bp.route("/search", methods=["GET"])
+@auth_required
+def search_sessions():
+    """
+    Search sessions for the authenticated user's courses.
+    """
+    query = request.args.get("q", "").strip()
+
+    if not query:
+        return success_response("Search query is empty", [])
+
+    sessions = search_sessions_for_user(g.user["id"], query)
+    return success_response("Search results retrieved successfully", sessions)
 
 
 @sessions_bp.route("/<int:session_id>", methods=["GET"])

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -104,6 +104,33 @@ def fetch_sessions_for_user(user_id: int) -> list[dict]:
     return [_row_to_dict(row) for row in rows]
 
 
+def search_sessions_for_user(user_id: int, query: str) -> list[dict]:
+    """
+    Search the authenticated user's course sessions by title or transcript content.
+    """
+    like_query = f"%{query}%"
+
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT s.id, s.title, s.original_filename, s.stored_path,
+                   s.status, s.course_id, s.created_at, s.updated_at
+            FROM sessions s
+            JOIN course_members cm ON cm.course_id = s.course_id
+            LEFT JOIN transcripts t ON t.session_id = s.id
+            WHERE cm.user_id = ?
+              AND (
+                  s.title LIKE ? COLLATE NOCASE
+                  OR t.content LIKE ? COLLATE NOCASE
+              )
+            ORDER BY s.created_at DESC
+            """,
+            (user_id, like_query, like_query),
+        ).fetchall()
+
+    return [_row_to_dict(row) for row in rows]
+
+
 def fetch_one_session(session_id: int) -> Optional[dict]:
     """
     Return one session by ID.

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -1,0 +1,67 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from forum_ai_notetaker import db
+from services.session_service import search_sessions_for_user
+
+
+class SessionSearchTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.original_db_path = db.DEFAULT_DB_PATH
+        db.DEFAULT_DB_PATH = Path(self.tempdir.name) / "test.sqlite3"
+        db.init_db()
+
+        with db.get_connection() as conn:
+            conn.executescript(
+                """
+                INSERT INTO users (id, email, name, password_hash, created_at, updated_at)
+                VALUES
+                    (1, 'member@example.com', 'Member', 'hash', datetime('now'), datetime('now')),
+                    (2, 'outsider@example.com', 'Outsider', 'hash', datetime('now'), datetime('now'));
+
+                INSERT INTO courses (id, name, invite_code, created_at, updated_at)
+                VALUES
+                    (1, 'Course One', 'COURSE1', datetime('now'), datetime('now')),
+                    (2, 'Course Two', 'COURSE2', datetime('now'), datetime('now'));
+
+                INSERT INTO course_members (course_id, user_id, role, created_at, updated_at)
+                VALUES (1, 1, 'student', datetime('now'), datetime('now'));
+
+                INSERT INTO sessions (
+                    id, title, original_filename, stored_path, status, course_id, created_at, updated_at
+                )
+                VALUES
+                    (1, 'Week 1 Review', 'week1.mp3', 'uploads/week1.mp3', 'notes_generated', 1, datetime('now'), datetime('now')),
+                    (2, 'Lab Recording', 'lab.mp3', 'uploads/lab.mp3', 'notes_generated', 1, datetime('now'), datetime('now')),
+                    (3, 'Private Lecture', 'private.mp3', 'uploads/private.mp3', 'notes_generated', 2, datetime('now'), datetime('now'));
+
+                INSERT INTO transcripts (session_id, content, created_at, updated_at)
+                VALUES
+                    (1, 'Today we cover vectors and matrices.', datetime('now'), datetime('now')),
+                    (2, 'This transcript mentions reinforcement learning.', datetime('now'), datetime('now')),
+                    (3, 'This private transcript also mentions reinforcement learning.', datetime('now'), datetime('now'));
+                """
+            )
+            conn.commit()
+
+    def tearDown(self):
+        db.DEFAULT_DB_PATH = self.original_db_path
+        self.tempdir.cleanup()
+
+    def test_search_matches_titles_and_transcripts_for_user_courses(self):
+        title_results = search_sessions_for_user(1, "review")
+        transcript_results = search_sessions_for_user(1, "reinforcement")
+
+        self.assertEqual([row["id"] for row in title_results], [1])
+        self.assertEqual([row["id"] for row in transcript_results], [2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -108,6 +108,11 @@ export function getSessions() {
   return request("/api/sessions/");
 }
 
+export function searchSessions(query) {
+  const params = new URLSearchParams({ q: query });
+  return request(`/api/sessions/search?${params.toString()}`);
+}
+
 export function uploadSession({ title, file }) {
   // File uploads must be sent as multipart/form-data.
   const formData = new FormData();

--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -108,11 +108,17 @@ export function getSessions() {
   return request("/api/sessions/");
 }
 
-export function uploadSession({ title, file }) {
-  // File uploads must be sent as multipart/form-data.
+export function getSession(sessionId) {
+  return request(`/api/sessions/${sessionId}`);
+}
+
+export function uploadSession({ title, file, courseId }) {
   const formData = new FormData();
   formData.append("title", title);
   formData.append("file", file);
+  if (courseId) {
+    formData.append("course_id", courseId);
+  }
 
   return request("/api/sessions/upload", {
     method: "POST",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -469,6 +469,21 @@ button:disabled {
   gap: 12px;
 }
 
+/* --- Search --- */
+
+.search-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  margin: 20px 0;
+}
+
+.search-form input {
+  padding: 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+}
+
 /* --- Upload --- */
 
 .upload-form {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -141,7 +141,8 @@ button:disabled {
   color: #374151;
 }
 
-.form-field input {
+.form-field input,
+.form-field select {
   padding: 10px;
   border: 1px solid #cbd5e1;
   border-radius: 8px;
@@ -154,7 +155,8 @@ button:disabled {
   box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.15);
 }
 
-.form-field input:disabled {
+.form-field input:disabled,
+.form-field select:disabled {
   opacity: 0.6;
   cursor: not-allowed;
   background-color: #f1f5f9;
@@ -512,5 +514,19 @@ button:disabled {
 .error-text {
   margin-top: 0;
   color: #b91c1c;
+  font-size: 14px;
+}
+
+/* --- Status messages --- */
+
+@keyframes pulse-text {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.status-processing {
+  margin: 6px 0 0;
+  animation: pulse-text 2s ease-in-out infinite;
+  color: #2563eb;
   font-size: 14px;
 }

--- a/frontend/src/pages/Notes.jsx
+++ b/frontend/src/pages/Notes.jsx
@@ -11,6 +11,8 @@ export default function Notes() {
   const [notes, setNotes] = useState(null);
 
   useEffect(() => {
+    let cancelled = false;
+
     async function loadData() {
       setLoading(true);
       setError("");
@@ -21,6 +23,8 @@ export default function Notes() {
           getTranscript(id),
           getNotes(id),
         ]);
+
+        if (cancelled) return;
 
         if (results[0].status === "rejected") {
           setError(results[0].reason?.message || "Failed to load session.");
@@ -36,13 +40,17 @@ export default function Notes() {
           setNotes(results[2].value.data);
         }
       } catch (err) {
-        setError(err.message || "Failed to load notes.");
+        if (!cancelled) setError(err.message || "Failed to load notes.");
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     }
 
     loadData();
+
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
   if (loading) {

--- a/frontend/src/pages/Notes.jsx
+++ b/frontend/src/pages/Notes.jsx
@@ -71,11 +71,20 @@ export default function Notes() {
 
   const status = session?.status;
 
+  const STATUS_LABELS = {
+    uploaded: "Uploaded",
+    processing: "Processing",
+    transcribed: "Transcribed",
+    notes_generated: "Ready",
+    failed: "Failed",
+  };
+  const KNOWN_STATUSES = Object.keys(STATUS_LABELS);
+
   return (
     <div className="container">
       <h1>{session?.title || `Session ${id}`}</h1>
       {status ? (
-        <p className="muted-text">Status: {status}</p>
+        <p className="muted-text">Status: {STATUS_LABELS[status] || status}</p>
       ) : null}
 
       {status === "processing" ? (
@@ -120,7 +129,7 @@ export default function Notes() {
       ) : null}
 
       {!transcript && !notes && status &&
-       !["processing", "failed", "uploaded", "transcribed"].includes(status) ? (
+       !KNOWN_STATUSES.includes(status) ? (
         <p className="muted-text">Content not yet available.</p>
       ) : null}
     </div>

--- a/frontend/src/pages/Notes.jsx
+++ b/frontend/src/pages/Notes.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { getNotes, getTranscript } from "../api/backend";
+import { getSession, getNotes, getTranscript } from "../api/backend";
 
 export default function Notes() {
-  // This comes from route /notes/:id.
   const { id } = useParams();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [session, setSession] = useState(null);
   const [transcript, setTranscript] = useState(null);
   const [notes, setNotes] = useState(null);
 
@@ -16,14 +16,26 @@ export default function Notes() {
       setError("");
 
       try {
-        // Fetch transcript + notes together for faster page load.
-        const [transcriptPayload, notesPayload] = await Promise.all([
+        const results = await Promise.allSettled([
+          getSession(id),
           getTranscript(id),
           getNotes(id),
         ]);
 
-        setTranscript(transcriptPayload.data);
-        setNotes(notesPayload.data);
+        if (results[0].status === "fulfilled") {
+          setSession(results[0].value.data);
+        }
+        if (results[1].status === "fulfilled") {
+          setTranscript(results[1].value.data);
+        }
+        if (results[2].status === "fulfilled") {
+          setNotes(results[2].value.data);
+        }
+
+        const failures = results.filter((r) => r.status === "rejected");
+        if (failures.length === results.length) {
+          setError("Failed to load session data.");
+        }
       } catch (err) {
         setError(err.message || "Failed to load notes.");
       } finally {
@@ -34,38 +46,75 @@ export default function Notes() {
     loadData();
   }, [id]);
 
+  if (loading) {
+    return (
+      <div className="container">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container">
+        <p className="error-text" role="alert">{error}</p>
+      </div>
+    );
+  }
+
+  const status = session?.status;
+
   return (
     <div className="container">
-      <h1>Session {id}</h1>
+      <h1>{session?.title || `Session ${id}`}</h1>
+      {status ? (
+        <p className="muted-text">Status: {status}</p>
+      ) : null}
 
-      {loading ? <p>Loading...</p> : null}
-      {error ? <p>{error}</p> : null}
+      {status === "processing" ? (
+        <p className="status-processing" role="status" aria-live="polite">
+          Transcription in progress...
+        </p>
+      ) : null}
 
-      {!loading && !error ? (
+      {status === "failed" ? (
+        <p className="error-text" role="alert">
+          Processing failed. The recording could not be transcribed.
+        </p>
+      ) : null}
+
+      {transcript ? (
         <>
           <h2>Transcript</h2>
-          <p>{transcript?.content || "Transcript not ready yet."}</p>
-
-          <h2>Notes</h2>
-          {notes ? (
-            <>
-              <p>
-                <strong>Summary:</strong> {notes.summary}
-              </p>
-
-              <p>
-                <strong>Topics:</strong> {(notes.topics || []).join(", ")}
-              </p>
-
-              <p>
-                <strong>Action items:</strong>{" "}
-                {(notes.action_items || []).join(", ")}
-              </p>
-            </>
-          ) : (
-            <p>Notes not generated yet.</p>
-          )}
+          <p>{transcript.content}</p>
         </>
+      ) : status === "uploaded" ? (
+        <p className="muted-text">Waiting for processing to start...</p>
+      ) : null}
+
+      {notes ? (
+        <>
+          <h2>Notes</h2>
+          <p>
+            <strong>Summary:</strong> {notes.summary}
+          </p>
+          <p>
+            <strong>Topics:</strong> {(notes.topics || []).join(", ")}
+          </p>
+          <p>
+            <strong>Action items:</strong>{" "}
+            {(notes.action_items || []).join(", ")}
+          </p>
+        </>
+      ) : status === "transcribed" ? (
+        <p className="muted-text">
+          Transcript is ready. Notes will be generated soon.
+        </p>
+      ) : null}
+
+      {!transcript && !notes && status &&
+       !["processing", "failed", "uploaded", "transcribed"].includes(status) ? (
+        <p className="muted-text">Content not yet available.</p>
       ) : null}
     </div>
   );

--- a/frontend/src/pages/Notes.jsx
+++ b/frontend/src/pages/Notes.jsx
@@ -22,19 +22,18 @@ export default function Notes() {
           getNotes(id),
         ]);
 
-        if (results[0].status === "fulfilled") {
-          setSession(results[0].value.data);
+        if (results[0].status === "rejected") {
+          setError(results[0].reason?.message || "Failed to load session.");
+          return;
         }
+
+        setSession(results[0].value.data);
+
         if (results[1].status === "fulfilled") {
           setTranscript(results[1].value.data);
         }
         if (results[2].status === "fulfilled") {
           setNotes(results[2].value.data);
-        }
-
-        const failures = results.filter((r) => r.status === "rejected");
-        if (failures.length === results.length) {
-          setError("Failed to load session data.");
         }
       } catch (err) {
         setError(err.message || "Failed to load notes.");

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -1,3 +1,80 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { searchSessions } from "../api/backend";
+
 export default function Search() {
-  return <div>Search</div>;
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState([]);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    const trimmedQuery = query.trim();
+    setHasSearched(true);
+    setError("");
+
+    if (!trimmedQuery) {
+      setResults([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const payload = await searchSessions(trimmedQuery);
+      setResults(payload.data || []);
+    } catch (err) {
+      setError(err.message || "Search failed.");
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="container">
+      <h1>Search sessions</h1>
+      <p className="muted-text">
+        Find recordings by session title or transcript content.
+      </p>
+
+      <form className="search-form" onSubmit={handleSubmit}>
+        <input
+          type="search"
+          placeholder="Search title or transcript"
+          aria-label="Search title or transcript"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <button type="submit" disabled={loading}>
+          {loading ? "Searching..." : "Search"}
+        </button>
+      </form>
+
+      {error ? (
+        <p className="error-text" role="alert">{error}</p>
+      ) : null}
+
+      {hasSearched && !loading && !error && results.length === 0 ? (
+        <p className="muted-text">No matching sessions found.</p>
+      ) : null}
+
+      {results.length > 0 ? (
+        <ul className="session-list">
+          {results.map((session) => (
+            <li className="session-card" key={session.id}>
+              <div>
+                <strong>{session.title}</strong>
+                <p className="muted-text">{session.original_filename}</p>
+                <p className="muted-text">Status: {session.status}</p>
+              </div>
+              <Link to={`/notes/${session.id}`}>View transcript/notes</Link>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
 }

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -1,61 +1,86 @@
-import { useState } from "react";
-import { uploadSession } from "../api/backend";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { uploadSession, getCourses } from "../api/backend";
 
 const ALLOWED_EXTENSIONS = ["mp4", "mp3", "wav", "m4a"];
 
 export default function Upload() {
   const [title, setTitle] = useState("");
   const [file, setFile] = useState(null);
+  const [courseId, setCourseId] = useState("");
+  const [courses, setCourses] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [loadingCourses, setLoadingCourses] = useState(true);
+  const [loadError, setLoadError] = useState("");
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const [isDragOver, setIsDragOver] = useState(false);
 
-  function isAllowedFile(candidateFile) {
-    if (!candidateFile?.name) {
-      return false;
-    }
+  useEffect(() => {
+    let cancelled = false;
+    getCourses()
+      .then((payload) => {
+        if (cancelled) return;
+        const eligible = (payload.data || []).filter(
+          (c) => c.role === "instructor" || c.role === "ta"
+        );
+        setCourses(eligible);
+        if (eligible.length === 1) {
+          setCourseId(String(eligible[0].id));
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setLoadError(err.message || "Could not load your courses. Please refresh the page.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingCourses(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
 
+  function isAllowedFile(candidateFile) {
+    if (!candidateFile?.name) return false;
     const ext = candidateFile.name.split(".").pop()?.toLowerCase();
     return ALLOWED_EXTENSIONS.includes(ext);
   }
 
   function handlePickedFile(candidateFile) {
-    if (!candidateFile) {
-      return;
-    }
-
+    if (!candidateFile) return;
     if (!isAllowedFile(candidateFile)) {
       setError("Unsupported file type. Use mp4, mp3, wav, or m4a.");
       return;
     }
-
     setError("");
     setFile(candidateFile);
   }
 
-  async function handleSubmit(event) {
-    // Prevent full page refresh so React can handle submit state.
-    event.preventDefault();
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (loading) return;
     setMessage("");
     setError("");
 
-    // Basic client-side checks before we call the backend.
+    if (!courseId) {
+      setError("Please select a course.");
+      return;
+    }
     if (!title.trim()) {
       setError("Title is required.");
       return;
     }
-
     if (!file) {
       setError("Please select a file.");
       return;
     }
 
     setLoading(true);
-
     try {
-      // Send upload request through our shared API helper.
-      const payload = await uploadSession({ title: title.trim(), file });
+      const payload = await uploadSession({
+        title: title.trim(),
+        file,
+        courseId,
+      });
       setMessage(payload.message || "Upload successful.");
       setTitle("");
       setFile(null);
@@ -66,12 +91,64 @@ export default function Upload() {
     }
   }
 
+  if (loadingCourses) {
+    return (
+      <div className="container">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="container">
+        <h1>Upload Session</h1>
+        <p className="error-text" role="alert">{loadError}</p>
+      </div>
+    );
+  }
+
+  if (courses.length === 0) {
+    return (
+      <div className="container">
+        <h1>Upload Session</h1>
+        <div className="empty-state">
+          <p>
+            You need to be an instructor or TA in a course to upload sessions.
+          </p>
+          <div className="empty-state-actions">
+            <Link to="/courses/create" className="btn-link">
+              Create a course
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="container">
       <h1>Upload Session</h1>
 
       <form className="upload-form" onSubmit={handleSubmit}>
-        <div>
+        <div className="form-field">
+          <label htmlFor="course">Course</label>
+          <select
+            id="course"
+            value={courseId}
+            onChange={(e) => setCourseId(e.target.value)}
+            disabled={loading}
+          >
+            <option value="">Select a course</option>
+            {courses.map((c) => (
+              <option key={c.id} value={String(c.id)}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="form-field">
           <label htmlFor="title">Title</label>
           <input
             id="title"
@@ -85,15 +162,15 @@ export default function Upload() {
 
         <div
           className={`upload-dropzone ${isDragOver ? "drag-over" : ""}`}
-          onDragOver={(event) => {
-            event.preventDefault();
+          onDragOver={(e) => {
+            e.preventDefault();
             setIsDragOver(true);
           }}
           onDragLeave={() => setIsDragOver(false)}
-          onDrop={(event) => {
-            event.preventDefault();
+          onDrop={(e) => {
+            e.preventDefault();
             setIsDragOver(false);
-            handlePickedFile(event.dataTransfer.files?.[0]);
+            handlePickedFile(e.dataTransfer.files?.[0]);
           }}
         >
           <label htmlFor="file">Recording</label>
@@ -101,7 +178,7 @@ export default function Upload() {
             id="file"
             type="file"
             accept=".mp4,.mp3,.wav,.m4a"
-            onChange={(event) => handlePickedFile(event.target.files?.[0])}
+            onChange={(e) => handlePickedFile(e.target.files?.[0])}
             disabled={loading}
           />
 
@@ -116,8 +193,8 @@ export default function Upload() {
         </button>
       </form>
 
-      {message ? <p className="success-text">{message}</p> : null}
-      {error ? <p className="error-text">{error}</p> : null}
+      {message ? <p className="success-text" role="status">{message}</p> : null}
+      {error ? <p className="error-text" role="alert">{error}</p> : null}
     </div>
   );
 }


### PR DESCRIPTION
## What changed
- Upload page now has a course dropdown filtered to courses where you're an instructor or TA
- If you have no eligible courses, shows a message with a link to create one
- If you only have one eligible course, it's auto-selected
- Upload sends course_id with the request so sessions are linked to courses
- Notes page shows different messages based on session status instead of generic "Notes not generated yet"
  - Processing: pulsing blue "Transcription in progress..." text
  - Uploaded: "Waiting for processing to start..."
  - Transcribed with no notes: shows transcript + "Notes will be generated soon"
  - Failed: red error message
  - Unknown status: generic fallback message
- Notes page now shows session title instead of just "Session 1"
- Added getSession API function for fetching individual session details
- Course-fetch errors on upload page are surfaced instead of silently swallowed

## Modified files
- `frontend/src/pages/Upload.jsx` - course dropdown filtered by role, sends course_id
- `frontend/src/pages/Notes.jsx` - fetches session status, conditional rendering per status
- `frontend/src/api/backend.js` - getSession function, uploadSession accepts courseId
- `frontend/src/index.css` - processing pulse animation, form-field select styling, disabled select state

## How to test
1. Go to upload as instructor/TA, should see course dropdown
2. If you only have one course, it should be pre-selected
3. Upload a recording to a course, go to the course page, session should appear
4. Register a student-only account, go to upload, should see message explaining you can't upload
5. Check notes page for different session statuses:
   - Processing: pulsing blue text
   - Transcribed: transcript shown + notes-coming message
   - Failed: red error