### PR TITLE
 rewrite note service to use sqlite

### DIFF
--- a/backend/forum_ai_notetaker/db.py
+++ b/backend/forum_ai_notetaker/db.py
@@ -10,6 +10,24 @@ DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "forum_ai_notetaker.sqlite3"
 SCHEMA_PATH = Path(__file__).with_name("schema.sql")
 
 
+def _column_exists(connection: sqlite3.Connection, table_name: str, column_name: str) -> bool:
+    rows = connection.execute(f"PRAGMA table_info({table_name})").fetchall()
+    return any(row[1] == column_name for row in rows)
+
+
+def _run_migrations(connection: sqlite3.Connection) -> None:
+    if not _column_exists(connection, "sessions", "course_id"):
+        connection.execute(
+            "ALTER TABLE sessions "
+            "ADD COLUMN course_id INTEGER DEFAULT NULL "
+            "REFERENCES courses(id) ON DELETE SET NULL"
+        )
+
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_course_id ON sessions(course_id)"
+    )
+
+
 def resolve_db_path(db_path: str | Path | None = None) -> Path:
     path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -22,6 +40,7 @@ def init_db(db_path: str | Path | None = None) -> Path:
     with sqlite3.connect(path) as connection:
         connection.execute("PRAGMA foreign_keys = ON;")
         connection.executescript(schema)
+        _run_migrations(connection)
     return path
 
 

--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -42,8 +42,10 @@ CREATE TABLE IF NOT EXISTS sessions (
     stored_path TEXT NOT NULL UNIQUE,
     status TEXT NOT NULL DEFAULT 'uploaded'
         CHECK (status IN ('uploaded', 'processing', 'transcribed', 'notes_generated', 'failed')),
+    course_id INTEGER DEFAULT NULL,
     created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE SET NULL
 );
 
 CREATE TABLE IF NOT EXISTS transcripts (

--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -55,5 +55,16 @@ CREATE TABLE IF NOT EXISTS transcripts (
     FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS notes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id INTEGER NOT NULL UNIQUE,
+    summary TEXT NOT NULL,
+    topics TEXT NOT NULL,
+    action_items TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);

--- a/backend/services/note_service.py
+++ b/backend/services/note_service.py
@@ -1,29 +1,66 @@
 """
 Notes service layer.
 
-This stores and returns generated notes. Again, this is mocked
-in memory for now so the full backend flow can be tested early.
+Connects generated notes to the SQLite database.
 """
 
+import json
+from datetime import datetime, timezone
 from typing import Optional
 
-NOTES = {}
+from forum_ai_notetaker.db import get_connection
+
+
+def _row_to_dict(row) -> dict:
+    return {
+        "id": row["id"],
+        "session_id": row["session_id"],
+        "summary": row["summary"],
+        "topics": json.loads(row["topics"]),
+        "action_items": json.loads(row["action_items"]),
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
 
 
 def save_notes(session_id: int, summary: str, topics: list[str], action_items: list[str]) -> None:
     """
     Save generated notes for a session.
     """
-    NOTES[session_id] = {
-        "session_id": session_id,
-        "summary": summary,
-        "topics": topics,
-        "action_items": action_items
-    }
+    now = datetime.now(timezone.utc).isoformat()
+    encoded_topics = json.dumps(topics)
+    encoded_action_items = json.dumps(action_items)
+
+    with get_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO notes (session_id, summary, topics, action_items, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                summary = excluded.summary,
+                topics = excluded.topics,
+                action_items = excluded.action_items,
+                updated_at = excluded.updated_at
+            """,
+            (session_id, summary, encoded_topics, encoded_action_items, now, now),
+        )
+        conn.commit()
+
+
+def get_notes_by_session(session_id: int) -> Optional[dict]:
+    """
+    Return generated notes for a session if they exist.
+    """
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT * FROM notes WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+    return _row_to_dict(row) if row else None
 
 
 def fetch_notes_by_session_id(session_id: int) -> Optional[dict]:
     """
-    Return generated notes for a session if they exist.
+    Backward-compatible wrapper used by the existing notes route.
     """
-    return NOTES.get(session_id)
+    return get_notes_by_session(session_id)


### PR DESCRIPTION
## what changed
- rewrote `note_service.py` to save notes in sqlite instead of in-memory storage
- added `get_notes_by_session()`
- kept `fetch_notes_by_session_id()` as a compatibility wrapper for the current route

## why
generated notes need to persist across restarts and match the rest of the backend data layer.

## how to test
- initialize the database
- create a session row
- call `save_notes()` and then `get_notes_by_session()`
- confirm the saved notes are returned from sqlite