### PR TITLE
chore: replace prints with logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,5 @@ If you see errors like `SSLCertVerificationError` while Whisper downloads `base.
 
 2. Retry:
    ```bash
-   python -c "import whisper; whisper.load_model('base.en'); print('whisper ok')"
+   python -c "import logging, whisper; logging.basicConfig(level=logging.INFO); whisper.load_model('base.en'); logging.info('whisper ok')"
    ```

--- a/backend/forum_ai_notetaker/__main__.py
+++ b/backend/forum_ai_notetaker/__main__.py
@@ -1,9 +1,14 @@
+import logging
+
 from .db import init_db
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO)
     db_path = init_db()
-    print(f"Initialized SQLite database at {db_path}")
+    logger.info("Initialized SQLite database at %s", db_path)
 
 
 if __name__ == "__main__":

--- a/backend/pipeline/trigger.py
+++ b/backend/pipeline/trigger.py
@@ -6,6 +6,7 @@ Extracts audio with FFmpeg, transcribes with Whisper,
 generates notes with Groq, and saves the results.
 """
 
+import logging
 from pathlib import Path
 
 from pipeline.audio import extract_audio
@@ -17,6 +18,8 @@ from services.groq_service import (
 from services.note_service import save_notes
 from services.session_service import update_session_status
 from services.transcript_service import save_transcript
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_recording_path(file_path: str) -> str:
@@ -47,10 +50,11 @@ def trigger_pipeline(file_path: str, session_id: int) -> None:
 
         try:
             notes = generate_notes_from_transcript(transcript_text)
-        except Exception as exc:
-            print(
-                f"Groq note generation failed for session {session_id}: {exc}. "
-                "Using fallback summary generation."
+        except Exception:
+            logger.exception(
+                "Groq note generation failed for session %s. "
+                "Using fallback summary generation.",
+                session_id,
             )
             notes = generate_fallback_notes(transcript_text)
 
@@ -61,6 +65,6 @@ def trigger_pipeline(file_path: str, session_id: int) -> None:
             notes["action_items"],
         )
         update_session_status(session_id, "notes_generated")
-    except Exception as exc:
-        print(f"Pipeline failed for session {session_id}: {exc}")
+    except Exception:
+        logger.exception("Pipeline failed for session %s", session_id)
         update_session_status(session_id, "failed")


### PR DESCRIPTION
## Summary
- Replace the SQLite init CLI print with logging
- Log Groq fallback and pipeline failures with logger.exception so tracebacks are preserved
- Update the README Whisper verification command to use logging

## Test
- python -m compileall backend/forum_ai_notetaker backend/pipeline