### PR TITLE
fix: added slash to preserve auth header

### DIFF
--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -105,7 +105,7 @@ export function updateMemberRole(courseId, userId, role) {
 // --- Sessions ---
 
 export function getSessions() {
-  return request("/api/sessions");
+  return request("/api/sessions/");
 }
 
 export function uploadSession({ title, file }) {


### PR DESCRIPTION
Fixes login bouncing users back to /login after valid credentials.

Problem: getSessions() called /api/sessions (no trailing slash). Flask 308-redirected to /api/sessions/ and the Authorization header was dropped on the redirect, causing a 401. The frontend's 401 handler then cleared the token and kicked the user back to login.

Fix: use the trailing slash, matching the other endpoints.

How to test:
  - Log in with valid credentials → lands on dashboard
  - Sessions list loads (no 401
  in backend logs)