### PR TITLE
Add session transcript search

### DIFF
--- a/backend/routes/sessions.py
+++ b/backend/routes/sessions.py
@@ -23,6 +23,7 @@ from services.session_service import (
     create_session_record,
     fetch_sessions_for_user,
     fetch_one_session,
+    search_sessions_for_user,
 )
 from services.course_service import get_course_by_id, is_course_member, is_ta_or_professor
 from pipeline.trigger import trigger_pipeline
@@ -38,6 +39,21 @@ def get_sessions():
     """
     sessions = fetch_sessions_for_user(g.user["id"])
     return success_response("Sessions retrieved successfully", sessions)
+
+
+@sessions_bp.route("/search", methods=["GET"])
+@auth_required
+def search_sessions():
+    """
+    Search sessions for the authenticated user's courses.
+    """
+    query = request.args.get("q", "").strip()
+
+    if not query:
+        return success_response("Search query is empty", [])
+
+    sessions = search_sessions_for_user(g.user["id"], query)
+    return success_response("Search results retrieved successfully", sessions)
 
 
 @sessions_bp.route("/<int:session_id>", methods=["GET"])

--- a/backend/services/session_service.py
+++ b/backend/services/session_service.py
@@ -104,6 +104,33 @@ def fetch_sessions_for_user(user_id: int) -> list[dict]:
     return [_row_to_dict(row) for row in rows]
 
 
+def search_sessions_for_user(user_id: int, query: str) -> list[dict]:
+    """
+    Search the authenticated user's course sessions by title or transcript content.
+    """
+    like_query = f"%{query}%"
+
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT s.id, s.title, s.original_filename, s.stored_path,
+                   s.status, s.course_id, s.created_at, s.updated_at
+            FROM sessions s
+            JOIN course_members cm ON cm.course_id = s.course_id
+            LEFT JOIN transcripts t ON t.session_id = s.id
+            WHERE cm.user_id = ?
+              AND (
+                  s.title LIKE ? COLLATE NOCASE
+                  OR t.content LIKE ? COLLATE NOCASE
+              )
+            ORDER BY s.created_at DESC
+            """,
+            (user_id, like_query, like_query),
+        ).fetchall()
+
+    return [_row_to_dict(row) for row in rows]
+
+
 def fetch_one_session(session_id: int) -> Optional[dict]:
     """
     Return one session by ID.

--- a/backend/tests/test_session_search.py
+++ b/backend/tests/test_session_search.py
@@ -1,0 +1,67 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from forum_ai_notetaker import db
+from services.session_service import search_sessions_for_user
+
+
+class SessionSearchTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.original_db_path = db.DEFAULT_DB_PATH
+        db.DEFAULT_DB_PATH = Path(self.tempdir.name) / "test.sqlite3"
+        db.init_db()
+
+        with db.get_connection() as conn:
+            conn.executescript(
+                """
+                INSERT INTO users (id, email, name, password_hash, created_at, updated_at)
+                VALUES
+                    (1, 'member@example.com', 'Member', 'hash', datetime('now'), datetime('now')),
+                    (2, 'outsider@example.com', 'Outsider', 'hash', datetime('now'), datetime('now'));
+
+                INSERT INTO courses (id, name, invite_code, created_at, updated_at)
+                VALUES
+                    (1, 'Course One', 'COURSE1', datetime('now'), datetime('now')),
+                    (2, 'Course Two', 'COURSE2', datetime('now'), datetime('now'));
+
+                INSERT INTO course_members (course_id, user_id, role, created_at, updated_at)
+                VALUES (1, 1, 'student', datetime('now'), datetime('now'));
+
+                INSERT INTO sessions (
+                    id, title, original_filename, stored_path, status, course_id, created_at, updated_at
+                )
+                VALUES
+                    (1, 'Week 1 Review', 'week1.mp3', 'uploads/week1.mp3', 'notes_generated', 1, datetime('now'), datetime('now')),
+                    (2, 'Lab Recording', 'lab.mp3', 'uploads/lab.mp3', 'notes_generated', 1, datetime('now'), datetime('now')),
+                    (3, 'Private Lecture', 'private.mp3', 'uploads/private.mp3', 'notes_generated', 2, datetime('now'), datetime('now'));
+
+                INSERT INTO transcripts (session_id, content, created_at, updated_at)
+                VALUES
+                    (1, 'Today we cover vectors and matrices.', datetime('now'), datetime('now')),
+                    (2, 'This transcript mentions reinforcement learning.', datetime('now'), datetime('now')),
+                    (3, 'This private transcript also mentions reinforcement learning.', datetime('now'), datetime('now'));
+                """
+            )
+            conn.commit()
+
+    def tearDown(self):
+        db.DEFAULT_DB_PATH = self.original_db_path
+        self.tempdir.cleanup()
+
+    def test_search_matches_titles_and_transcripts_for_user_courses(self):
+        title_results = search_sessions_for_user(1, "review")
+        transcript_results = search_sessions_for_user(1, "reinforcement")
+
+        self.assertEqual([row["id"] for row in title_results], [1])
+        self.assertEqual([row["id"] for row in transcript_results], [2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -108,6 +108,11 @@ export function getSessions() {
   return request("/api/sessions/");
 }
 
+export function searchSessions(query) {
+  const params = new URLSearchParams({ q: query });
+  return request(`/api/sessions/search?${params.toString()}`);
+}
+
 export function uploadSession({ title, file }) {
   // File uploads must be sent as multipart/form-data.
   const formData = new FormData();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -469,6 +469,21 @@ button:disabled {
   gap: 12px;
 }
 
+/* --- Search --- */
+
+.search-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  margin: 20px 0;
+}
+
+.search-form input {
+  padding: 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+}
+
 /* --- Upload --- */
 
 .upload-form {

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -1,3 +1,80 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { searchSessions } from "../api/backend";
+
 export default function Search() {
-  return <div>Search</div>;
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState([]);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    const trimmedQuery = query.trim();
+    setHasSearched(true);
+    setError("");
+
+    if (!trimmedQuery) {
+      setResults([]);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const payload = await searchSessions(trimmedQuery);
+      setResults(payload.data || []);
+    } catch (err) {
+      setError(err.message || "Search failed.");
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="container">
+      <h1>Search sessions</h1>
+      <p className="muted-text">
+        Find recordings by session title or transcript content.
+      </p>
+
+      <form className="search-form" onSubmit={handleSubmit}>
+        <input
+          type="search"
+          placeholder="Search title or transcript"
+          aria-label="Search title or transcript"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <button type="submit" disabled={loading}>
+          {loading ? "Searching..." : "Search"}
+        </button>
+      </form>
+
+      {error ? (
+        <p className="error-text" role="alert">{error}</p>
+      ) : null}
+
+      {hasSearched && !loading && !error && results.length === 0 ? (
+        <p className="muted-text">No matching sessions found.</p>
+      ) : null}
+
+      {results.length > 0 ? (
+        <ul className="session-list">
+          {results.map((session) => (
+            <li className="session-card" key={session.id}>
+              <div>
+                <strong>{session.title}</strong>
+                <p className="muted-text">{session.original_filename}</p>
+                <p className="muted-text">Status: {session.status}</p>
+              </div>
+              <Link to={`/notes/${session.id}`}>View transcript/notes</Link>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add an authenticated session search endpoint using LIKE against session titles and transcript content
- wire the frontend Search page to call the backend and render matching sessions
- add a temporary SQLite service test covering title/transcript matches scoped to a user's courses


## Checks
- `python -m unittest discover backend/tests`
- `npm run lint`