### PR TITLE
Add pre-release schema review

### DIFF
--- a/backend/SCHEMA_REVIEW.md
+++ b/backend/SCHEMA_REVIEW.md
@@ -1,0 +1,49 @@
+# Schema Review
+
+Date: 2026-04-20
+
+Scope:
+- `backend/forum_ai_notetaker/schema.sql`
+- `backend/forum_ai_notetaker/db.py`
+- Course, session, transcript, and note data-access paths
+
+## Final Tag Status
+
+No schema blockers were found for a final tag as long as course deletion is not included in the release surface.
+
+The current schema supports:
+- Users with unique email addresses.
+- Courses with unique invite codes.
+- Course membership with one role per user per course.
+- Sessions linked to courses through `sessions.course_id`.
+- One transcript and one generated note record per session.
+- Foreign key enforcement through `PRAGMA foreign_keys = ON` in `init_db` and `get_connection`.
+
+Foreign key behavior to verify before tagging:
+- `course_members.course_id -> courses.id ON DELETE CASCADE`
+- `course_members.user_id -> users.id ON DELETE CASCADE`
+- `sessions.course_id -> courses.id ON DELETE SET NULL`
+- `transcripts.session_id -> sessions.id ON DELETE CASCADE`
+- `notes.session_id -> sessions.id ON DELETE CASCADE`
+
+PR #42 adds regression coverage for these checks.
+
+## Gaps And Follow-Ups
+
+1. Course deletion needs an explicit product decision before it ships.
+   The schema currently keeps session content and sets `sessions.course_id` to `NULL` when a course is deleted. That matches the declared foreign key, but course-linked transcript and note access depends on course membership. If a course delete endpoint is added, choose one of these policies first:
+   - Restrict course deletion while sessions exist.
+   - Cascade-delete sessions, transcripts, and notes with the course.
+   - Keep orphaned sessions but add a first-class owner or access-control field.
+
+2. Migration tracking is still informal.
+   `_run_migrations` currently handles only the `sessions.course_id` backfill path. Before the next schema change, add a real migration ledger or migration directory so applied changes are auditable.
+
+3. Search is intentionally simple.
+   PR #41 uses `LIKE` against session titles and transcript content. This is acceptable for the current app size, but leading-wildcard searches will not benefit from a normal index. Move to SQLite FTS5 if transcript volume grows.
+
+4. Some indexes duplicate unique constraints.
+   `users.email` and `courses.invite_code` already create unique indexes. The explicit indexes are harmless, but can be removed in a later cleanup if schema minimalism matters.
+
+5. Timestamp defaults live in application code.
+   Every table requires `created_at` and `updated_at`, and services currently supply those values. Keep that convention consistent, or move defaults into the schema in a future migration.

--- a/backend/routes/sessions.py
+++ b/backend/routes/sessions.py
@@ -88,14 +88,6 @@ def upload_session():
     - the user must be authenticated
     - a course_id must be provided in the request
     - the user must be a TA or professor for that course
-
-    Important:
-    The current database schema does not yet link sessions to courses.
-    Because of this, course_id is used only for permission validation
-    at upload time and is not persisted with the session.
-
-    This keeps the permission logic in place without introducing
-    inconsistencies with the existing data model.
     """
 
     if "file" not in request.files:


### PR DESCRIPTION
## Summary
- add a pre-release schema review for the SQLite data model
- document foreign key behavior and final-tag follow-ups
- remove a stale upload-route comment that said sessions were not linked to courses

## Checks
- `python -m py_compile backend/routes/sessions.py`