### PR TITLE
chore: add Docker setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in the value.
+# If left blank, note generation falls back to a local heuristic summary
+# so the app still works end-to-end without a Groq account.
+GROQ_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -23,7 +23,36 @@ Upload recording → Extract audio (FFmpeg) → Transcribe (Whisper) → Save to
 4. Whisper (`base.en` model) transcribes the audio to text
 5. Transcript is saved to SQLite and session status is updated
 
-## Setup
+## Quick Start (Docker)
+
+One-command setup. Docker handles Python, Node, FFmpeg, and the Whisper model for you.
+
+```bash
+cp .env.example .env          # optional: paste your Groq key into .env
+docker compose up --build
+```
+
+- Frontend: http://localhost:5173
+- Backend API: http://localhost:5000
+
+The Groq API key is **provided separately** with the assignment submission — no signup needed. If `.env` is empty or missing, the app still works end-to-end: note generation falls back to a local heuristic summary instead of calling Groq.
+
+### Architecture
+
+```
+┌──────────────────┐        ┌──────────────────────────────────┐
+│  frontend (nginx)│        │          backend (gunicorn)      │
+│  React build     │  /api  │  Flask + Whisper + FFmpeg        │
+│  port 5173 → 80  │ ─────▶ │  port 5000                       │
+└──────────────────┘        │                                  │
+                            │  ./data   → /app/data (sqlite)   │
+                            │  ./uploads → /app/backend/uploads│
+                            └──────────────────────────────────┘
+```
+
+Two containers on the default Compose network. nginx serves the built React app and proxies `/api/*` to the backend by service name. SQLite and uploaded recordings are bind-mounted so data survives container restarts. The Whisper `base.en` model is baked into the backend image, so the first transcription does not need internet.
+
+## Manual Setup (without Docker)
 
 ### Prerequisites
 

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,14 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.venv
+venv
+env
+myenv
+uploads/*
+!uploads/.gitkeep
+*.db
+*.sqlite
+*.sqlite3
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.7
+
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    XDG_CACHE_HOME=/root/.cache
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Separate ENV so apt cache above is preserved; these vars apply to every
+# pip/sub-pip call below, including PEP 517 build-isolation subprocesses.
+ENV PIP_DEFAULT_TIMEOUT=300 \
+    PIP_RETRIES=10
+
+COPY backend/requirements.txt /app/backend/requirements.txt
+RUN pip install -r /app/backend/requirements.txt
+
+# Preload Whisper base.en so first request is fast and works offline.
+RUN python -c "import whisper; whisper.load_model('base.en')"
+
+COPY backend /app/backend
+
+RUN mkdir -p /app/data /app/backend/uploads
+
+WORKDIR /app/backend
+
+EXPOSE 5000
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "--threads", "4", "--timeout", "600", "app:app"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ openai-whisper==20250625
 PyJWT==2.12.1
 python-dotenv==1.2.2
 Werkzeug==3.1.6
+gunicorn==23.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+    volumes:
+      - ./data:/app/data
+      - ./backend/uploads:/app/backend/uploads
+    ports:
+      - "5000:5000"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    depends_on:
+      - backend
+    ports:
+      - "5173:80"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+.env.local
+npm-debug.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Large upload ceiling for lecture recordings.
+    client_max_body_size 500M;
+
+    location /api/ {
+        proxy_pass http://backend:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
  - Adds Docker setup: `backend/Dockerfile` (Python + FFmpeg + preloaded Whisper + gunicorn), multi-stage `frontend/Dockerfile` (node build → nginx serve), and `docker-compose.yml` wiring both services on the default Compose network
  - Frontend nginx proxies `/api/*` to `backend:5000`; SQLite (`./data`) and uploads (`./backend/uploads`) bind-mounted so data survives restarts
  - `.env.example` with `GROQ_API_KEY` placeholder — app falls back to local heuristic note generation when the key is missing, so it still runs end-to-end

  ## Test plan
  - [ ] Fresh clone → `cp .env.example .env` (paste real key) → `docker compose up --build` → upload a recording → transcript + Groq notes generated
  - [ ] Fresh clone → leave `.env` empty → `docker compose up --build` → upload works, backend logs show "Using fallback summary generation"
  - [ ] `curl http://localhost:5000/api/health` returns `{"status":"ok"}`
  - [ ] `curl http://localhost:5173/api/health` (nginx proxy) returns the same