### PR TITLE
Make upload flow course-centered

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -69,6 +69,18 @@ nav {
   padding: 32px;
 }
 
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.page-header h1 {
+  margin: 0;
+}
+
 /* --- Buttons --- */
 
 button {

--- a/frontend/src/pages/Course.jsx
+++ b/frontend/src/pages/Course.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useLocation } from "react-router-dom";
 import { getCourse, getCourseSessions, updateMemberRole } from "../api/backend";
 
 export default function Course() {
   const { id } = useParams();
+  const location = useLocation();
   const [course, setCourse] = useState(null);
   const [sessions, setSessions] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -77,14 +78,30 @@ export default function Course() {
 
   const isInstructor = course.your_role === "instructor";
   const canSeeCode = course.your_role === "instructor" || course.your_role === "ta";
+  const canUpload = canSeeCode;
+  const uploadSuccess = location.state?.uploadSuccess;
 
   return (
     <div className="container">
-      <div className="course-header">
-        <h1>{course.name}</h1>
-        <span className={`role-badge role-badge--${course.your_role || "student"}`}>
-          {course.your_role}
-        </span>
+      <div className="page-header">
+        <div>
+          <div className="course-header">
+            <h1>{course.name}</h1>
+            <span className={`role-badge role-badge--${course.your_role || "student"}`}>
+              {course.your_role}
+            </span>
+          </div>
+          <p className="muted-text">
+            {canUpload
+              ? "Upload recordings directly into this course."
+              : "View sessions and notes shared with this course."}
+          </p>
+        </div>
+        {canUpload ? (
+          <Link to={`/courses/${id}/upload`} className="btn-link">
+            Upload session
+          </Link>
+        ) : null}
       </div>
 
       {canSeeCode && course.invite_code ? (
@@ -92,6 +109,12 @@ export default function Course() {
           <p className="muted-text">Invite code</p>
           <div className="invite-code-display">{course.invite_code}</div>
         </div>
+      ) : null}
+
+      {uploadSuccess ? (
+        <p className="success-text" role="status">
+          Uploaded {uploadSuccess.title}. It now belongs to this course.
+        </p>
       ) : null}
 
       <h2 className="section-heading">
@@ -131,7 +154,11 @@ export default function Course() {
       {sessions.length === 0 ? (
         <p className="muted-text">
           No sessions in this course yet.{" "}
-          <Link to="/upload">Upload one</Link>
+          {canUpload ? (
+            <Link to={`/courses/${id}/upload`}>Upload one</Link>
+          ) : (
+            "Ask your instructor or TA to upload one."
+          )}
         </p>
       ) : (
         <ul className="session-list">

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { uploadSession, getCourses } from "../api/backend";
 
 const ALLOWED_EXTENSIONS = ["mp4", "mp3", "wav", "m4a"];
 
 export default function Upload() {
+  const navigate = useNavigate();
+  const { id: routeCourseId } = useParams();
   const [title, setTitle] = useState("");
   const [file, setFile] = useState(null);
   const [courseId, setCourseId] = useState("");
@@ -15,6 +17,7 @@ export default function Upload() {
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const [isDragOver, setIsDragOver] = useState(false);
+  const isCourseScoped = Boolean(routeCourseId);
 
   useEffect(() => {
     let cancelled = false;
@@ -25,6 +28,17 @@ export default function Upload() {
           (c) => c.role === "instructor" || c.role === "ta"
         );
         setCourses(eligible);
+        if (routeCourseId) {
+          const matchedCourse = eligible.find(
+            (course) => String(course.id) === routeCourseId
+          );
+          if (!matchedCourse) {
+            setLoadError("You do not have permission to upload to this course.");
+            return;
+          }
+          setCourseId(routeCourseId);
+          return;
+        }
         if (eligible.length === 1) {
           setCourseId(String(eligible[0].id));
         }
@@ -37,7 +51,12 @@ export default function Upload() {
         if (!cancelled) setLoadingCourses(false);
       });
     return () => { cancelled = true; };
-  }, []);
+  }, [routeCourseId]);
+
+  const selectedCourse = useMemo(
+    () => courses.find((course) => String(course.id) === String(courseId)) || null,
+    [courseId, courses]
+  );
 
   function isAllowedFile(candidateFile) {
     if (!candidateFile?.name) return false;
@@ -81,9 +100,21 @@ export default function Upload() {
         file,
         courseId,
       });
+      const createdSession = payload.data;
+      const destinationCourseId = String(courseId);
+
       setMessage(payload.message || "Upload successful.");
       setTitle("");
       setFile(null);
+
+      navigate(`/courses/${destinationCourseId}`, {
+        state: {
+          uploadSuccess: {
+            sessionId: createdSession?.id,
+            title: createdSession?.title || title.trim(),
+          },
+        },
+      });
     } catch (err) {
       setError(err.message || "Upload failed.");
     } finally {
@@ -128,7 +159,21 @@ export default function Upload() {
 
   return (
     <div className="container">
-      <h1>Upload Session</h1>
+      <div className="page-header">
+        <div>
+          <h1>Upload Session</h1>
+          <p className="muted-text">
+            {selectedCourse
+              ? `Uploading into ${selectedCourse.name}.`
+              : "Choose the course this recording belongs to."}
+          </p>
+        </div>
+        {selectedCourse ? (
+          <Link to={`/courses/${selectedCourse.id}`} className="btn-link btn-link--secondary">
+            Back to course
+          </Link>
+        ) : null}
+      </div>
 
       <form className="upload-form" onSubmit={handleSubmit}>
         <div className="form-field">
@@ -137,7 +182,7 @@ export default function Upload() {
             id="course"
             value={courseId}
             onChange={(e) => setCourseId(e.target.value)}
-            disabled={loading}
+            disabled={loading || isCourseScoped}
           >
             <option value="">Select a course</option>
             {courses.map((c) => (

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -49,6 +49,14 @@ export default function AppRouter() {
         }
       />
       <Route
+        path="/courses/:id/upload"
+        element={
+          <ProtectedRoute>
+            <Upload />
+          </ProtectedRoute>
+        }
+      />
+      <Route
         path="/notes/:id"
         element={
           <ProtectedRoute>


### PR DESCRIPTION
## Summary
This PR makes the upload experience feel more connected to the course a user is working in.

Previously, uploads happened through a generic /upload page. This change adds a course-specific upload entry point so instructors and TAs can start from a course page, upload directly into that course, and return to the course context after submission.

## Changes

- added a course-scoped upload route: /courses/:id/upload
- added an Upload session CTA on the course page for instructors and TAs
- updated the upload page to:
- preselect the course when opened from a course page
- lock the course selector in course-scoped mode
- show clearer course context in the header
- navigate back to the course page after a successful upload
- updated the empty course state to link to course-specific upload when appropriate
- added small layout styling for the new page header pattern

## Why
This supports the iteration goal of making uploads match the user’s mental model:

- recordings belong to a course
- users often start from the course they are already viewing
- after uploading, users should stay in that course workflow rather than returning to a generic screen
<img width="1512" height="905" alt="Screenshot 2026-04-20 at 8 26 26 AM" src="https://github.com/user-attachments/assets/abea6f24-5c8e-400a-9e91-298618055cb8" />
