### PR TITLE
Unify session status UI

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -69,6 +69,18 @@ nav {
   padding: 32px;
 }
 
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.page-header h1 {
+  margin: 0;
+}
+
 /* --- Buttons --- */
 
 button {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -525,6 +525,81 @@ button:disabled {
   background: #eff6ff;
 }
 
+/* --- Session detail --- */
+
+.notes-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.notes-meta-item {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+
+.notes-meta-item strong {
+  color: #1e293b;
+  display: block;
+  font-size: 15px;
+}
+
+.notes-meta-label {
+  color: #64748b;
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+
+.notes-section + .notes-section {
+  margin-top: 24px;
+}
+
+.notes-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.notes-block {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  padding: 18px 20px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.notes-block h3 {
+  color: #1e293b;
+  font-size: 16px;
+  margin: 0 0 10px;
+}
+
+.notes-block p {
+  color: #334155;
+  line-height: 1.65;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.notes-list {
+  color: #334155;
+  display: grid;
+  gap: 8px;
+  line-height: 1.55;
+  margin: 0;
+  padding-left: 20px;
+}
+
+.notes-list li::marker {
+  color: #2563eb;
+}
+
 /* --- Utility --- */
 
 .muted-text {
@@ -556,4 +631,14 @@ button:disabled {
   animation: pulse-text 2s ease-in-out infinite;
   color: #2563eb;
   font-size: 14px;
+}
+
+@media (max-width: 720px) {
+  .page-header {
+    flex-direction: column;
+  }
+
+  .notes-block {
+    padding: 16px;
+  }
 }

--- a/frontend/src/pages/Course.jsx
+++ b/frontend/src/pages/Course.jsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useLocation } from "react-router-dom";
 import { getCourse, getCourseSessions, updateMemberRole } from "../api/backend";
 
 export default function Course() {
   const { id } = useParams();
+  const location = useLocation();
   const [course, setCourse] = useState(null);
   const [sessions, setSessions] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -77,14 +78,30 @@ export default function Course() {
 
   const isInstructor = course.your_role === "instructor";
   const canSeeCode = course.your_role === "instructor" || course.your_role === "ta";
+  const canUpload = canSeeCode;
+  const uploadSuccess = location.state?.uploadSuccess;
 
   return (
     <div className="container">
-      <div className="course-header">
-        <h1>{course.name}</h1>
-        <span className={`role-badge role-badge--${course.your_role || "student"}`}>
-          {course.your_role}
-        </span>
+      <div className="page-header">
+        <div>
+          <div className="course-header">
+            <h1>{course.name}</h1>
+            <span className={`role-badge role-badge--${course.your_role || "student"}`}>
+              {course.your_role}
+            </span>
+          </div>
+          <p className="muted-text">
+            {canUpload
+              ? "Upload recordings directly into this course."
+              : "View sessions and notes shared with this course."}
+          </p>
+        </div>
+        {canUpload ? (
+          <Link to={`/courses/${id}/upload`} className="btn-link">
+            Upload session
+          </Link>
+        ) : null}
       </div>
 
       {canSeeCode && course.invite_code ? (
@@ -92,6 +109,12 @@ export default function Course() {
           <p className="muted-text">Invite code</p>
           <div className="invite-code-display">{course.invite_code}</div>
         </div>
+      ) : null}
+
+      {uploadSuccess ? (
+        <p className="success-text" role="status">
+          Uploaded {uploadSuccess.title}. It now belongs to this course.
+        </p>
       ) : null}
 
       <h2 className="section-heading">
@@ -131,7 +154,11 @@ export default function Course() {
       {sessions.length === 0 ? (
         <p className="muted-text">
           No sessions in this course yet.{" "}
-          <Link to="/upload">Upload one</Link>
+          {canUpload ? (
+            <Link to={`/courses/${id}/upload`}>Upload one</Link>
+          ) : (
+            "Ask your instructor or TA to upload one."
+          )}
         </p>
       ) : (
         <ul className="session-list">

--- a/frontend/src/pages/Course.jsx
+++ b/frontend/src/pages/Course.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, Link, useLocation } from "react-router-dom";
 import { getCourse, getCourseSessions, updateMemberRole } from "../api/backend";
+import { getSessionStatusLabel } from "../utils/sessionStatus";
 
 export default function Course() {
   const { id } = useParams();
@@ -167,7 +168,9 @@ export default function Course() {
               <div>
                 <strong>{session.title}</strong>
                 <p className="muted-text">{session.original_filename}</p>
-                <p className="muted-text">Status: {session.status}</p>
+                <p className="muted-text">
+                  Status: {getSessionStatusLabel(session.status)}
+                </p>
               </div>
               <Link to={`/notes/${session.id}`}>View transcript/notes</Link>
             </li>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { getCourses, getSessions } from "../api/backend";
+import {
+  getSessionStatusLabel,
+  SESSION_STATUS_FILTERS,
+} from "../utils/sessionStatus";
 
 export default function Dashboard() {
   const [courses, setCourses] = useState([]);
@@ -45,11 +49,11 @@ export default function Dashboard() {
 
   const summary = useMemo(() => {
     const total = sessions.length;
-    const transcribed = sessions.filter(
-      (s) => s.status === "transcribed"
+    const ready = sessions.filter(
+      (s) => s.status === "transcribed" || s.status === "notes_generated"
     ).length;
     const failed = sessions.filter((s) => s.status === "failed").length;
-    return { total, transcribed, failed };
+    return { total, ready, failed };
   }, [sessions]);
 
   const filteredSessions = useMemo(() => {
@@ -125,8 +129,8 @@ export default function Dashboard() {
           <strong>{summary.total}</strong>
         </div>
         <div className="stat-card">
-          <span>Transcribed</span>
-          <strong>{summary.transcribed}</strong>
+          <span>Ready</span>
+          <strong>{summary.ready}</strong>
         </div>
         <div className="stat-card">
           <span>Failed</span>
@@ -148,10 +152,11 @@ export default function Dashboard() {
           aria-label="Filter by status"
         >
           <option value="all">All statuses</option>
-          <option value="uploaded">Uploaded</option>
-          <option value="processing">Processing</option>
-          <option value="transcribed">Transcribed</option>
-          <option value="failed">Failed</option>
+          {SESSION_STATUS_FILTERS.map((statusOption) => (
+            <option key={statusOption.value} value={statusOption.value}>
+              {statusOption.label}
+            </option>
+          ))}
         </select>
       </div>
 
@@ -164,7 +169,9 @@ export default function Dashboard() {
               <div>
                 <strong>{session.title}</strong>
                 <p className="muted-text">{session.original_filename}</p>
-                <p className="muted-text">Status: {session.status}</p>
+                <p className="muted-text">
+                  Status: {getSessionStatusLabel(session.status)}
+                </p>
               </div>
               <Link to={`/notes/${session.id}`}>View transcript/notes</Link>
             </li>

--- a/frontend/src/pages/Notes.jsx
+++ b/frontend/src/pages/Notes.jsx
@@ -2,6 +2,25 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { getSession, getNotes, getTranscript } from "../api/backend";
 
+const STATUS_LABELS = {
+  uploaded: "Uploaded",
+  processing: "Processing",
+  transcribed: "Transcript Ready",
+  notes_generated: "Notes Ready",
+  failed: "Failed",
+};
+
+function formatTimestamp(value) {
+  if (!value) return "Unknown";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}
+
 export default function Notes() {
   const { id } = useParams();
   const [loading, setLoading] = useState(true);
@@ -70,26 +89,37 @@ export default function Notes() {
   }
 
   const status = session?.status;
-
-  const STATUS_LABELS = {
-    uploaded: "Uploaded",
-    processing: "Processing",
-    transcribed: "Transcribed",
-    notes_generated: "Ready",
-    failed: "Failed",
-  };
   const KNOWN_STATUSES = Object.keys(STATUS_LABELS);
+  const topics = notes?.topics || [];
+  const actionItems = notes?.action_items || [];
+  const hasTranscript = Boolean(transcript?.content);
+  const hasNotes = Boolean(notes);
 
   return (
     <div className="container">
-      <h1>{session?.title || `Session ${id}`}</h1>
-      {status ? (
-        <p className="muted-text">Status: {STATUS_LABELS[status] || status}</p>
-      ) : null}
+      <div className="page-header">
+        <div>
+          <h1>{session?.title || `Session ${id}`}</h1>
+          {session?.original_filename ? (
+            <p className="muted-text">Original file: {session.original_filename}</p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="notes-meta">
+        <div className="notes-meta-item">
+          <span className="notes-meta-label">Status</span>
+          <strong>{STATUS_LABELS[status] || status || "Unknown"}</strong>
+        </div>
+        <div className="notes-meta-item">
+          <span className="notes-meta-label">Last updated</span>
+          <strong>{formatTimestamp(session?.updated_at)}</strong>
+        </div>
+      </div>
 
       {status === "processing" ? (
         <p className="status-processing" role="status" aria-live="polite">
-          Transcription in progress...
+          We&apos;re still processing this recording.
         </p>
       ) : null}
 
@@ -99,37 +129,68 @@ export default function Notes() {
         </p>
       ) : null}
 
-      {transcript ? (
-        <>
-          <h2>Transcript</h2>
-          <p>{transcript.content}</p>
-        </>
-      ) : status === "uploaded" ? (
-        <p className="muted-text">Waiting for processing to start...</p>
-      ) : null}
+      <section className="notes-section">
+        <h2 className="section-heading">Study Notes</h2>
 
-      {notes ? (
-        <>
-          <h2>Notes</h2>
-          <p>
-            <strong>Summary:</strong> {notes.summary}
-          </p>
-          <p>
-            <strong>Topics:</strong> {(notes.topics || []).join(", ")}
-          </p>
-          <p>
-            <strong>Action items:</strong>{" "}
-            {(notes.action_items || []).join(", ")}
-          </p>
-        </>
-      ) : status === "transcribed" ? (
-        <p className="muted-text">
-          Transcript is ready. Notes will be generated soon.
-        </p>
-      ) : null}
+        {hasNotes ? (
+          <div className="notes-stack">
+            <div className="notes-block">
+              <h3>Summary</h3>
+              <p>{notes.summary}</p>
+            </div>
 
-      {!transcript && !notes && status &&
-       !KNOWN_STATUSES.includes(status) ? (
+            <div className="notes-block">
+              <h3>Topics</h3>
+              {topics.length > 0 ? (
+                <ul className="notes-list">
+                  {topics.map((topic, index) => (
+                    <li key={`${topic}-${index}`}>{topic}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="muted-text">No topics were extracted yet.</p>
+              )}
+            </div>
+
+            <div className="notes-block">
+              <h3>Action Items</h3>
+              {actionItems.length > 0 ? (
+                <ul className="notes-list">
+                  {actionItems.map((item, index) => (
+                    <li key={`${item}-${index}`}>{item}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="muted-text">No action items were identified.</p>
+              )}
+            </div>
+          </div>
+        ) : status === "transcribed" ? (
+          <p className="muted-text">
+            The transcript is ready. Study notes will appear here once generation finishes.
+          </p>
+        ) : status === "uploaded" || status === "processing" ? (
+          <p className="muted-text">
+            Study notes will appear here after the recording is processed.
+          </p>
+        ) : null}
+      </section>
+
+      <section className="notes-section">
+        <h2 className="section-heading">Transcript</h2>
+
+        {hasTranscript ? (
+          <div className="notes-block">
+            <p>{transcript.content}</p>
+          </div>
+        ) : status === "uploaded" ? (
+          <p className="muted-text">Waiting for processing to start...</p>
+        ) : status === "processing" ? (
+          <p className="muted-text">Transcript will appear here once processing is complete.</p>
+        ) : null}
+      </section>
+
+      {!hasTranscript && !hasNotes && status && !KNOWN_STATUSES.includes(status) ? (
         <p className="muted-text">Content not yet available.</p>
       ) : null}
     </div>

--- a/frontend/src/pages/Notes.jsx
+++ b/frontend/src/pages/Notes.jsx
@@ -1,14 +1,10 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { getSession, getNotes, getTranscript } from "../api/backend";
-
-const STATUS_LABELS = {
-  uploaded: "Uploaded",
-  processing: "Processing",
-  transcribed: "Transcript Ready",
-  notes_generated: "Notes Ready",
-  failed: "Failed",
-};
+import {
+  getSessionStatusLabel,
+  SESSION_STATUS_LABELS,
+} from "../utils/sessionStatus";
 
 function formatTimestamp(value) {
   if (!value) return "Unknown";
@@ -89,7 +85,7 @@ export default function Notes() {
   }
 
   const status = session?.status;
-  const KNOWN_STATUSES = Object.keys(STATUS_LABELS);
+  const KNOWN_STATUSES = Object.keys(SESSION_STATUS_LABELS);
   const topics = notes?.topics || [];
   const actionItems = notes?.action_items || [];
   const hasTranscript = Boolean(transcript?.content);
@@ -109,7 +105,7 @@ export default function Notes() {
       <div className="notes-meta">
         <div className="notes-meta-item">
           <span className="notes-meta-label">Status</span>
-          <strong>{STATUS_LABELS[status] || status || "Unknown"}</strong>
+          <strong>{getSessionStatusLabel(status)}</strong>
         </div>
         <div className="notes-meta-item">
           <span className="notes-meta-label">Last updated</span>

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { searchSessions } from "../api/backend";
+import { getSessionStatusLabel } from "../utils/sessionStatus";
 
 export default function Search() {
   const [query, setQuery] = useState("");
@@ -68,7 +69,9 @@ export default function Search() {
               <div>
                 <strong>{session.title}</strong>
                 <p className="muted-text">{session.original_filename}</p>
-                <p className="muted-text">Status: {session.status}</p>
+                <p className="muted-text">
+                  Status: {getSessionStatusLabel(session.status)}
+                </p>
               </div>
               <Link to={`/notes/${session.id}`}>View transcript/notes</Link>
             </li>

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { uploadSession, getCourses } from "../api/backend";
 
 const ALLOWED_EXTENSIONS = ["mp4", "mp3", "wav", "m4a"];
 
 export default function Upload() {
+  const navigate = useNavigate();
+  const { id: routeCourseId } = useParams();
   const [title, setTitle] = useState("");
   const [file, setFile] = useState(null);
   const [courseId, setCourseId] = useState("");
@@ -15,6 +17,7 @@ export default function Upload() {
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const [isDragOver, setIsDragOver] = useState(false);
+  const isCourseScoped = Boolean(routeCourseId);
 
   useEffect(() => {
     let cancelled = false;
@@ -25,6 +28,17 @@ export default function Upload() {
           (c) => c.role === "instructor" || c.role === "ta"
         );
         setCourses(eligible);
+        if (routeCourseId) {
+          const matchedCourse = eligible.find(
+            (course) => String(course.id) === routeCourseId
+          );
+          if (!matchedCourse) {
+            setLoadError("You do not have permission to upload to this course.");
+            return;
+          }
+          setCourseId(routeCourseId);
+          return;
+        }
         if (eligible.length === 1) {
           setCourseId(String(eligible[0].id));
         }
@@ -37,7 +51,12 @@ export default function Upload() {
         if (!cancelled) setLoadingCourses(false);
       });
     return () => { cancelled = true; };
-  }, []);
+  }, [routeCourseId]);
+
+  const selectedCourse = useMemo(
+    () => courses.find((course) => String(course.id) === String(courseId)) || null,
+    [courseId, courses]
+  );
 
   function isAllowedFile(candidateFile) {
     if (!candidateFile?.name) return false;
@@ -81,9 +100,21 @@ export default function Upload() {
         file,
         courseId,
       });
+      const createdSession = payload.data;
+      const destinationCourseId = String(courseId);
+
       setMessage(payload.message || "Upload successful.");
       setTitle("");
       setFile(null);
+
+      navigate(`/courses/${destinationCourseId}`, {
+        state: {
+          uploadSuccess: {
+            sessionId: createdSession?.id,
+            title: createdSession?.title || title.trim(),
+          },
+        },
+      });
     } catch (err) {
       setError(err.message || "Upload failed.");
     } finally {
@@ -128,7 +159,21 @@ export default function Upload() {
 
   return (
     <div className="container">
-      <h1>Upload Session</h1>
+      <div className="page-header">
+        <div>
+          <h1>Upload Session</h1>
+          <p className="muted-text">
+            {selectedCourse
+              ? `Uploading into ${selectedCourse.name}.`
+              : "Choose the course this recording belongs to."}
+          </p>
+        </div>
+        {selectedCourse ? (
+          <Link to={`/courses/${selectedCourse.id}`} className="btn-link btn-link--secondary">
+            Back to course
+          </Link>
+        ) : null}
+      </div>
 
       <form className="upload-form" onSubmit={handleSubmit}>
         <div className="form-field">
@@ -137,7 +182,7 @@ export default function Upload() {
             id="course"
             value={courseId}
             onChange={(e) => setCourseId(e.target.value)}
-            disabled={loading}
+            disabled={loading || isCourseScoped}
           >
             <option value="">Select a course</option>
             {courses.map((c) => (

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -49,6 +49,14 @@ export default function AppRouter() {
         }
       />
       <Route
+        path="/courses/:id/upload"
+        element={
+          <ProtectedRoute>
+            <Upload />
+          </ProtectedRoute>
+        }
+      />
+      <Route
         path="/notes/:id"
         element={
           <ProtectedRoute>

--- a/frontend/src/utils/sessionStatus.js
+++ b/frontend/src/utils/sessionStatus.js
@@ -1,0 +1,19 @@
+export const SESSION_STATUS_LABELS = {
+  uploaded: "Uploaded",
+  processing: "Processing",
+  transcribed: "Transcript Ready",
+  notes_generated: "Notes Ready",
+  failed: "Failed",
+};
+
+export const SESSION_STATUS_FILTERS = [
+  { value: "uploaded", label: "Uploaded" },
+  { value: "processing", label: "Processing" },
+  { value: "transcribed", label: "Transcript Ready" },
+  { value: "notes_generated", label: "Notes Ready" },
+  { value: "failed", label: "Failed" },
+];
+
+export function getSessionStatusLabel(status) {
+  return SESSION_STATUS_LABELS[status] || status || "Unknown";
+}


### PR DESCRIPTION
## Summary
This PR makes session statuses more consistent and understandable across the frontend.

Previously, different parts of the app handled session states differently. In particular, successful sessions could end in notes_generated, while some views still emphasized transcribed or displayed raw backend status values. This update introduces a shared status mapping and applies it across the dashboard, course page, search results, and session detail view.

## Changes

- added a shared session status helper in frontend/src/utils/sessionStatus.js
- centralized frontend labels for:
  uploaded
  processing
  transcribed
  notes_generated
  failed
- updated the dashboard to:
  count both transcribed and notes_generated as Ready
  include notes_generated in the status filter
  display user-friendly status labels on session cards
- updated course page session cards to use shared status labels
- updated search result cards to use shared status labels
- updated the notes/session detail page to use the shared status label helper

## Why
This supports the iteration goal of making session progress easier for users to understand.

The change addresses a UX inconsistency where:

- completed sessions were not always represented as complete
- some views surfaced raw backend values instead of user-friendly wording
- users could get mixed signals about whether a session was ready
