### PR TITLE
Gate course creation, joining, and upload by user type

### DIFF
--- a/backend/forum_ai_notetaker/db.py
+++ b/backend/forum_ai_notetaker/db.py
@@ -27,6 +27,13 @@ def _run_migrations(connection: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_sessions_course_id ON sessions(course_id)"
     )
 
+    if not _column_exists(connection, "users", "user_type"):
+        connection.execute(
+            "ALTER TABLE users "
+            "ADD COLUMN user_type TEXT NOT NULL DEFAULT 'student' "
+            "CHECK (user_type IN ('student', 'professor'))"
+        )
+
 
 def resolve_db_path(db_path: str | Path | None = None) -> Path:
     path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH

--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS users (
     email TEXT NOT NULL UNIQUE,
     name TEXT NOT NULL,
     password_hash TEXT NOT NULL,
+    user_type TEXT NOT NULL DEFAULT 'student'
+        CHECK (user_type IN ('student', 'professor')),
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -27,6 +27,7 @@ auth_bp = Blueprint("auth", __name__)
 EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 MIN_PASSWORD_LENGTH = 8
 MAX_NAME_LENGTH = 100
+ALLOWED_USER_TYPES = {"student", "professor"}
 
 
 @auth_bp.route("/register", methods=["POST"])
@@ -50,6 +51,7 @@ def register():
     email = (data.get("email") or "").strip().lower()
     name = (data.get("name") or "").strip()
     password = data.get("password") or ""
+    user_type = (data.get("user_type") or "student").strip().lower()
 
     errors = []
     if not email or not EMAIL_REGEX.match(email):
@@ -58,6 +60,8 @@ def register():
         errors.append(f"Name is required and must be under {MAX_NAME_LENGTH} characters")
     if len(password) < MIN_PASSWORD_LENGTH:
         errors.append(f"Password must be at least {MIN_PASSWORD_LENGTH} characters")
+    if user_type not in ALLOWED_USER_TYPES:
+        errors.append("Account type must be 'student' or 'professor'")
 
     if errors:
         return error_response("; ".join(errors), 400)
@@ -65,7 +69,12 @@ def register():
     password_hash = generate_password_hash(password, method="pbkdf2:sha256")
 
     try:
-        user = create_user(email=email, name=name, password_hash=password_hash)
+        user = create_user(
+            email=email,
+            name=name,
+            password_hash=password_hash,
+            user_type=user_type,
+        )
     except sqlite3.IntegrityError:
         return error_response("Email is already registered", 409)
 

--- a/backend/routes/courses.py
+++ b/backend/routes/courses.py
@@ -24,6 +24,7 @@ from services.course_service import (
     join_course_by_invite_code,
 )
 from services.course_member_service import get_course_member, update_course_member_role
+from services.user_service import get_user_by_id
 from utils.responses import error_response, success_response
 
 
@@ -41,6 +42,9 @@ def create_new_course():
         "name": "..."
     }
     """
+    if g.user.get("user_type") != "professor":
+        return error_response("Only professors can create courses", 403)
+
     data = request.get_json(silent=True) or {}
     name = data.get("name", "").strip()
 
@@ -72,6 +76,9 @@ def join_course():
     data = request.get_json(silent=True)
     if data is None:
         return error_response("Request body must be JSON", 400)
+
+    if g.user.get("user_type") != "student":
+        return error_response("Only student accounts can join courses via invite code", 403)
 
     invite_code = (data.get("invite_code") or "").strip().upper()
     if not invite_code:

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -26,7 +26,12 @@ def _row_to_dict(row) -> dict:
     return dict(row)
 
 
-def create_user(email: str, name: str, password_hash: str) -> dict:
+def create_user(
+    email: str,
+    name: str,
+    password_hash: str,
+    user_type: str = "student",
+) -> dict:
     """
     Create a new user record.
 
@@ -37,6 +42,8 @@ def create_user(email: str, name: str, password_hash: str) -> dict:
         email: The user's unique email address.
         name: The user's display name.
         password_hash: The hashed password to store.
+        user_type: Global account type, either 'student' or 'professor'.
+            Determines which course roles the user can hold.
 
     Returns:
         A dictionary representing the created user, excluding the
@@ -50,16 +57,16 @@ def create_user(email: str, name: str, password_hash: str) -> dict:
     with get_connection() as conn:
         cursor = conn.execute(
             """
-            INSERT INTO users (email, name, password_hash, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO users (email, name, password_hash, user_type, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (email, name, password_hash, now, now),
+            (email, name, password_hash, user_type, now, now),
         )
         conn.commit()
 
         row = conn.execute(
             """
-            SELECT id, email, name, created_at
+            SELECT id, email, name, user_type, created_at
             FROM users
             WHERE id = ?
             """,
@@ -86,7 +93,7 @@ def get_user_by_email(email: str) -> Optional[dict]:
     with get_connection() as conn:
         row = conn.execute(
             """
-            SELECT id, email, name, password_hash, created_at
+            SELECT id, email, name, password_hash, user_type, created_at
             FROM users
             WHERE email = ?
             """,
@@ -114,7 +121,7 @@ def get_user_by_id(user_id: int) -> Optional[dict]:
     with get_connection() as conn:
         row = conn.execute(
             """
-            SELECT id, email, name, created_at
+            SELECT id, email, name, user_type, created_at
             FROM users
             WHERE id = ?
             """,

--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -52,11 +52,11 @@ export function loginUser(email, password) {
   });
 }
 
-export function registerUser(name, email, password) {
+export function registerUser(name, email, password, userType) {
   return request("/api/auth/register", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, email, password }),
+    body: JSON.stringify({ name, email, password, user_type: userType }),
   });
 }
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -3,6 +3,7 @@ import useAuth from "../hooks/useAuth";
 
 export default function Navbar() {
   const { user, logout } = useAuth();
+  const isProfessor = user?.user_type === "professor";
 
   return (
     <nav>
@@ -10,8 +11,11 @@ export default function Navbar() {
         {user ? (
           <>
             <Link to="/">Dashboard</Link>
-            <Link to="/courses/create">Create Course</Link>
-            <Link to="/courses/join">Join Course</Link>
+            {isProfessor ? (
+              <Link to="/courses/create">Create Course</Link>
+            ) : (
+              <Link to="/courses/join">Join Course</Link>
+            )}
             <Link to="/upload">Upload</Link>
             <Link to="/search">Search</Link>
           </>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,9 +1,36 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
+import { getCourses } from "../api/backend";
 
 export default function Navbar() {
   const { user, logout } = useAuth();
   const isProfessor = user?.user_type === "professor";
+  const [canUpload, setCanUpload] = useState(isProfessor);
+
+  useEffect(() => {
+    if (!user) {
+      setCanUpload(false);
+      return;
+    }
+    if (isProfessor) {
+      setCanUpload(true);
+      return;
+    }
+    let cancelled = false;
+    getCourses()
+      .then((payload) => {
+        if (cancelled) return;
+        const eligible = (payload.data || []).some(
+          (c) => c.role === "instructor" || c.role === "ta"
+        );
+        setCanUpload(eligible);
+      })
+      .catch(() => {
+        if (!cancelled) setCanUpload(false);
+      });
+    return () => { cancelled = true; };
+  }, [user, isProfessor]);
 
   return (
     <nav>
@@ -16,7 +43,7 @@ export default function Navbar() {
             ) : (
               <Link to="/courses/join">Join Course</Link>
             )}
-            <Link to="/upload">Upload</Link>
+            {canUpload ? <Link to="/upload">Upload</Link> : null}
             <Link to="/search">Search</Link>
           </>
         ) : (

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -6,17 +6,11 @@ import { getCourses } from "../api/backend";
 export default function Navbar() {
   const { user, logout } = useAuth();
   const isProfessor = user?.user_type === "professor";
-  const [canUpload, setCanUpload] = useState(isProfessor);
+  const [isTaSomewhere, setIsTaSomewhere] = useState(false);
+  const canUpload = Boolean(user) && (isProfessor || isTaSomewhere);
 
   useEffect(() => {
-    if (!user) {
-      setCanUpload(false);
-      return;
-    }
-    if (isProfessor) {
-      setCanUpload(true);
-      return;
-    }
+    if (!user || isProfessor) return;
     let cancelled = false;
     getCourses()
       .then((payload) => {
@@ -24,10 +18,10 @@ export default function Navbar() {
         const eligible = (payload.data || []).some(
           (c) => c.role === "instructor" || c.role === "ta"
         );
-        setCanUpload(eligible);
+        setIsTaSomewhere(eligible);
       })
       .catch(() => {
-        if (!cancelled) setCanUpload(false);
+        if (!cancelled) setIsTaSomewhere(false);
       });
     return () => { cancelled = true; };
   }, [user, isProfessor]);

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -35,8 +35,8 @@ export default function AuthProvider({ children }) {
     return payload;
   }, []);
 
-  const register = useCallback(async (name, email, password) => {
-    const payload = await registerUser(name, email, password);
+  const register = useCallback(async (name, email, password, userType) => {
+    const payload = await registerUser(name, email, password, userType);
     localStorage.setItem("token", payload.data.token);
     setUser(payload.data.user);
     return payload;

--- a/frontend/src/pages/CreateCourse.jsx
+++ b/frontend/src/pages/CreateCourse.jsx
@@ -1,8 +1,10 @@
 import { useState, useRef, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { createCourse } from "../api/backend";
+import useAuth from "../hooks/useAuth";
 
 export default function CreateCourse() {
+  const { user } = useAuth();
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -15,6 +17,10 @@ export default function CreateCourse() {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, []);
+
+  if (user && user.user_type !== "professor") {
+    return <Navigate to="/" replace />;
+  }
 
   async function handleSubmit(e) {
     e.preventDefault();

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { getCourses, getSessions } from "../api/backend";
+import useAuth from "../hooks/useAuth";
 import {
   getSessionStatusLabel,
   SESSION_STATUS_FILTERS,
 } from "../utils/sessionStatus";
 
 export default function Dashboard() {
+  const { user } = useAuth();
+  const isProfessor = user?.user_type === "professor";
   const [courses, setCourses] = useState([]);
   const [sessions, setSessions] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -98,8 +101,11 @@ export default function Dashboard() {
         <div className="empty-state">
           <p>You are not in any courses yet.</p>
           <div className="empty-state-actions">
-            <Link to="/courses/create" className="btn-link">Create a course</Link>
-            <Link to="/courses/join" className="btn-link btn-link--secondary">Join a course</Link>
+            {isProfessor ? (
+              <Link to="/courses/create" className="btn-link">Create a course</Link>
+            ) : (
+              <Link to="/courses/join" className="btn-link">Join a course</Link>
+            )}
           </div>
         </div>
       ) : (

--- a/frontend/src/pages/JoinCourse.jsx
+++ b/frontend/src/pages/JoinCourse.jsx
@@ -1,12 +1,18 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import { joinCourse } from "../api/backend";
+import useAuth from "../hooks/useAuth";
 
 export default function JoinCourse() {
+  const { user } = useAuth();
   const navigate = useNavigate();
   const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+
+  if (user && user.user_type !== "student") {
+    return <Navigate to="/" replace />;
+  }
 
   async function handleSubmit(e) {
     e.preventDefault();

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -10,6 +10,7 @@ export default function Register() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [userType, setUserType] = useState("student");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -36,7 +37,7 @@ export default function Register() {
 
     setLoading(true);
     try {
-      await register(name.trim(), email.trim().toLowerCase(), password);
+      await register(name.trim(), email.trim().toLowerCase(), password, userType);
       navigate("/", { replace: true });
     } catch (err) {
       setError(err.message || "Registration failed.");
@@ -88,6 +89,34 @@ export default function Register() {
               disabled={loading}
               autoComplete="new-password"
             />
+          </div>
+
+          <div className="form-field">
+            <label>I am a</label>
+            <div className="user-type-options">
+              <label className="user-type-option">
+                <input
+                  type="radio"
+                  name="user-type"
+                  value="student"
+                  checked={userType === "student"}
+                  onChange={() => setUserType("student")}
+                  disabled={loading}
+                />
+                <span>Student</span>
+              </label>
+              <label className="user-type-option">
+                <input
+                  type="radio"
+                  name="user-type"
+                  value="professor"
+                  checked={userType === "professor"}
+                  onChange={() => setUserType("professor")}
+                  disabled={loading}
+                />
+                <span>Professor</span>
+              </label>
+            </div>
           </div>
 
           <div className="form-field">

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { uploadSession, getCourses } from "../api/backend";
+import useAuth from "../hooks/useAuth";
 
 const ALLOWED_EXTENSIONS = ["mp4", "mp3", "wav", "m4a"];
 
 export default function Upload() {
   const navigate = useNavigate();
   const { id: routeCourseId } = useParams();
+  const { user } = useAuth();
+  const isProfessor = user?.user_type === "professor";
   const [title, setTitle] = useState("");
   const [file, setFile] = useState(null);
   const [courseId, setCourseId] = useState("");
@@ -145,13 +148,17 @@ export default function Upload() {
         <h1>Upload Session</h1>
         <div className="empty-state">
           <p>
-            You need to be an instructor or TA in a course to upload sessions.
+            {isProfessor
+              ? "You need to create a course before uploading recordings."
+              : "Only TAs and instructors can upload recordings. Ask your instructor to promote you to TA."}
           </p>
-          <div className="empty-state-actions">
-            <Link to="/courses/create" className="btn-link">
-              Create a course
-            </Link>
-          </div>
+          {isProfessor ? (
+            <div className="empty-state-actions">
+              <Link to="/courses/create" className="btn-link">
+                Create a course
+              </Link>
+            </div>
+          ) : null}
         </div>
       </div>
     );


### PR DESCRIPTION
## Checklist

- [x] This PR targets `main`.
- [x] I checked that this PR does not accidentally target another feature branch.
- [x] I ran or reviewed the relevant checks for this change.


Body:

  ## Summary
  - Adds `user_type` (`student` | `professor`) to the users table, selected at signup.
  - Professors can only create courses and be instructors; students can only join courses and be promoted to TA.
  - Hides the Upload link from students who gated; this fixes the UX gap).

  ## Changes
  - **Backend:** schema + migration for `user_type`; register route validates it; `POST /courses/` requires professor; `POST /courses/join` requires student.
  - **Frontend:** Student/Professor selector on signup; navbar and dashboard show role-appropriate actions; Create/Join pages redirect users who hit them from the wrong role; Upload link hidden unless the user has TA/instructor in at least one course.

  ## Test plan
  - [ ] Sign up as a professor → see "Create Course" in navbar, no "Join Course", can create a course.
  - [ ] Sign up as a student → see "Join Course" in navbar, no "Create Course", no "Upload" link.
  - [ ] Student joins a course via invite code → still no "Upload" link.
  - [ ] Instructor promotes the student to TA → "Upload" link appears, student can upload to that course.
  - [ ] Direct-URL check: students hitting `/courses/create` and professors hitting `/courses/join` are redirected to `/`.
  - [ ] API check: professor calling `POST /courses/join` returns 403; student calling `POST /courses/` returns 403.
