### PR TITLE
feat: Timed transcripts

### DIFF
--- a/backend/forum_ai_notetaker/db.py
+++ b/backend/forum_ai_notetaker/db.py
@@ -34,6 +34,12 @@ def _run_migrations(connection: sqlite3.Connection) -> None:
             "CHECK (user_type IN ('student', 'professor'))"
         )
 
+    if not _column_exists(connection, "transcripts", "segments"):
+        connection.execute(
+            "ALTER TABLE transcripts "
+            "ADD COLUMN segments TEXT NOT NULL DEFAULT '[]'"
+        )
+
 
 def resolve_db_path(db_path: str | Path | None = None) -> Path:
     path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH

--- a/backend/forum_ai_notetaker/db.py
+++ b/backend/forum_ai_notetaker/db.py
@@ -27,6 +27,13 @@ def _run_migrations(connection: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_sessions_course_id ON sessions(course_id)"
     )
 
+    if not _column_exists(connection, "users", "user_type"):
+        connection.execute(
+            "ALTER TABLE users "
+            "ADD COLUMN user_type TEXT NOT NULL DEFAULT 'student' "
+            "CHECK (user_type IN ('student', 'professor'))"
+        )
+
 
 def resolve_db_path(db_path: str | Path | None = None) -> Path:
     path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH

--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS users (
     email TEXT NOT NULL UNIQUE,
     name TEXT NOT NULL,
     password_hash TEXT NOT NULL,
+    user_type TEXT NOT NULL DEFAULT 'student'
+        CHECK (user_type IN ('student', 'professor')),
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS transcripts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id INTEGER NOT NULL UNIQUE,
     content TEXT NOT NULL,
+    segments TEXT NOT NULL DEFAULT '[]',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE

--- a/backend/pipeline/process.py
+++ b/backend/pipeline/process.py
@@ -14,7 +14,7 @@ from .audio import extract_audio
 from .transcribe import transcribe_audio
 
 
-def process_recording(file_path: str) -> str:
+def process_recording(file_path: str) -> tuple[str, list[dict]]:
     """
     Run the end-to-end Sprint 1 processing pipeline for one recording file.
 
@@ -22,7 +22,7 @@ def process_recording(file_path: str) -> str:
         file_path: Path to uploaded video file.
 
     Returns:
-        Transcript text.
+        A tuple of (transcript_text, segments).
 
     Raises:
         ValueError: If file_path is invalid.
@@ -40,11 +40,11 @@ def process_recording(file_path: str) -> str:
 
     # Step 2: Transcribe audio
     try:
-        transcript = transcribe_audio(audio_path)
+        transcript, segments = transcribe_audio(audio_path)
     except (ValueError, FileNotFoundError) as exc:
         # Re-raise path validation errors as-is
         raise
     except RuntimeError as exc:
         raise RuntimeError(f"Transcription failed: {exc}") from exc
 
-    return transcript
+    return transcript, segments

--- a/backend/pipeline/transcribe.py
+++ b/backend/pipeline/transcribe.py
@@ -1,6 +1,7 @@
 """Transcription step for the Sprint 1 pipeline.
 
-This module loads Whisper base.en and returns transcript text for one audio file.
+This module loads Whisper base.en and returns transcript text and
+timestamped segments for one audio file.
 """
 
 from __future__ import annotations
@@ -10,7 +11,7 @@ from pathlib import Path
 import whisper
 
 
-def transcribe_audio(audio_path: str) -> str:
+def transcribe_audio(audio_path: str) -> tuple[str, list[dict]]:
     """
     Transcribe an audio file to text using Whisper base.en.
 
@@ -18,7 +19,9 @@ def transcribe_audio(audio_path: str) -> str:
         audio_path: Path to input audio file (expected WAV for this pipeline).
 
     Returns:
-        Transcript text as a string.
+        A tuple of (transcript_text, segments), where each segment is a dict
+        with keys ``start`` (float seconds), ``end`` (float seconds), and
+        ``text`` (str).
 
     Raises:
         ValueError: If audio_path is empty or invalid.
@@ -75,4 +78,18 @@ def transcribe_audio(audio_path: str) -> str:
             "Check that the audio file contains audible speech."
         )
 
-    return text
+    raw_segments = (result or {}).get("segments") or []
+    segments: list[dict] = []
+    for seg in raw_segments:
+        seg_text = (seg.get("text") or "").strip()
+        if not seg_text:
+            continue
+        segments.append(
+            {
+                "start": float(seg.get("start", 0.0)),
+                "end": float(seg.get("end", 0.0)),
+                "text": seg_text,
+            }
+        )
+
+    return text, segments

--- a/backend/pipeline/trigger.py
+++ b/backend/pipeline/trigger.py
@@ -45,8 +45,8 @@ def trigger_pipeline(file_path: str, session_id: int) -> None:
     try:
         absolute_recording_path = _resolve_recording_path(file_path)
         audio_path = extract_audio(absolute_recording_path)
-        transcript_text = transcribe_audio(audio_path)
-        save_transcript(session_id, transcript_text)
+        transcript_text, segments = transcribe_audio(audio_path)
+        save_transcript(session_id, transcript_text, segments)
 
         try:
             notes = generate_notes_from_transcript(transcript_text)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -27,6 +27,7 @@ auth_bp = Blueprint("auth", __name__)
 EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 MIN_PASSWORD_LENGTH = 8
 MAX_NAME_LENGTH = 100
+ALLOWED_USER_TYPES = {"student", "professor"}
 
 
 @auth_bp.route("/register", methods=["POST"])
@@ -50,6 +51,7 @@ def register():
     email = (data.get("email") or "").strip().lower()
     name = (data.get("name") or "").strip()
     password = data.get("password") or ""
+    user_type = (data.get("user_type") or "student").strip().lower()
 
     errors = []
     if not email or not EMAIL_REGEX.match(email):
@@ -58,6 +60,8 @@ def register():
         errors.append(f"Name is required and must be under {MAX_NAME_LENGTH} characters")
     if len(password) < MIN_PASSWORD_LENGTH:
         errors.append(f"Password must be at least {MIN_PASSWORD_LENGTH} characters")
+    if user_type not in ALLOWED_USER_TYPES:
+        errors.append("Account type must be 'student' or 'professor'")
 
     if errors:
         return error_response("; ".join(errors), 400)
@@ -65,7 +69,12 @@ def register():
     password_hash = generate_password_hash(password, method="pbkdf2:sha256")
 
     try:
-        user = create_user(email=email, name=name, password_hash=password_hash)
+        user = create_user(
+            email=email,
+            name=name,
+            password_hash=password_hash,
+            user_type=user_type,
+        )
     except sqlite3.IntegrityError:
         return error_response("Email is already registered", 409)
 

--- a/backend/routes/courses.py
+++ b/backend/routes/courses.py
@@ -24,6 +24,7 @@ from services.course_service import (
     join_course_by_invite_code,
 )
 from services.course_member_service import get_course_member, update_course_member_role
+from services.user_service import get_user_by_id
 from utils.responses import error_response, success_response
 
 
@@ -41,6 +42,9 @@ def create_new_course():
         "name": "..."
     }
     """
+    if g.user.get("user_type") != "professor":
+        return error_response("Only professors can create courses", 403)
+
     data = request.get_json(silent=True) or {}
     name = data.get("name", "").strip()
 
@@ -72,6 +76,9 @@ def join_course():
     data = request.get_json(silent=True)
     if data is None:
         return error_response("Request body must be JSON", 400)
+
+    if g.user.get("user_type") != "student":
+        return error_response("Only student accounts can join courses via invite code", 403)
 
     invite_code = (data.get("invite_code") or "").strip().upper()
     if not invite_code:

--- a/backend/services/transcript_service.py
+++ b/backend/services/transcript_service.py
@@ -5,16 +5,22 @@ This module connects transcript-related routes and pipeline output
 to the SQLite database.
 
 A transcript belongs to a session and stores the transcribed text
-generated from an uploaded recording.
+generated from an uploaded recording, along with a JSON-encoded list
+of timestamped segments.
 """
 
+import json
 from datetime import datetime, timezone
 from typing import Optional
 
 from forum_ai_notetaker.db import get_connection
 
 
-def save_transcript(session_id: int, transcript_text: str) -> None:
+def save_transcript(
+    session_id: int,
+    transcript_text: str,
+    segments: Optional[list[dict]] = None,
+) -> None:
     """
     Save a transcript for a session in the database.
 
@@ -24,16 +30,18 @@ def save_transcript(session_id: int, transcript_text: str) -> None:
     Args:
         session_id: The session this transcript belongs to.
         transcript_text: The full transcript text.
+        segments: Optional list of ``{start, end, text}`` dicts.
     """
     now = datetime.now(timezone.utc).isoformat()
+    segments_json = json.dumps(segments or [])
 
     with get_connection() as conn:
         conn.execute(
             """
-            INSERT INTO transcripts (session_id, content, created_at, updated_at)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO transcripts (session_id, content, segments, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
             """,
-            (session_id, transcript_text, now, now),
+            (session_id, transcript_text, segments_json, now, now),
         )
         conn.commit()
 
@@ -50,7 +58,8 @@ def fetch_transcript_by_session_id(session_id: int) -> Optional[dict]:
         session_id: The session being requested.
 
     Returns:
-        A transcript dictionary if it exists, otherwise None.
+        A transcript dictionary if it exists, otherwise None. The
+        ``segments`` field is decoded into a list of dicts.
     """
     with get_connection() as conn:
         row = conn.execute(
@@ -61,4 +70,13 @@ def fetch_transcript_by_session_id(session_id: int) -> Optional[dict]:
             (session_id,),
         ).fetchone()
 
-    return dict(row) if row else None
+    if not row:
+        return None
+
+    transcript = dict(row)
+    raw_segments = transcript.get("segments")
+    try:
+        transcript["segments"] = json.loads(raw_segments) if raw_segments else []
+    except (TypeError, ValueError):
+        transcript["segments"] = []
+    return transcript

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -26,7 +26,12 @@ def _row_to_dict(row) -> dict:
     return dict(row)
 
 
-def create_user(email: str, name: str, password_hash: str) -> dict:
+def create_user(
+    email: str,
+    name: str,
+    password_hash: str,
+    user_type: str = "student",
+) -> dict:
     """
     Create a new user record.
 
@@ -37,6 +42,8 @@ def create_user(email: str, name: str, password_hash: str) -> dict:
         email: The user's unique email address.
         name: The user's display name.
         password_hash: The hashed password to store.
+        user_type: Global account type, either 'student' or 'professor'.
+            Determines which course roles the user can hold.
 
     Returns:
         A dictionary representing the created user, excluding the
@@ -50,16 +57,16 @@ def create_user(email: str, name: str, password_hash: str) -> dict:
     with get_connection() as conn:
         cursor = conn.execute(
             """
-            INSERT INTO users (email, name, password_hash, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO users (email, name, password_hash, user_type, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (email, name, password_hash, now, now),
+            (email, name, password_hash, user_type, now, now),
         )
         conn.commit()
 
         row = conn.execute(
             """
-            SELECT id, email, name, created_at
+            SELECT id, email, name, user_type, created_at
             FROM users
             WHERE id = ?
             """,
@@ -86,7 +93,7 @@ def get_user_by_email(email: str) -> Optional[dict]:
     with get_connection() as conn:
         row = conn.execute(
             """
-            SELECT id, email, name, password_hash, created_at
+            SELECT id, email, name, password_hash, user_type, created_at
             FROM users
             WHERE email = ?
             """,
@@ -114,7 +121,7 @@ def get_user_by_id(user_id: int) -> Optional[dict]:
     with get_connection() as conn:
         row = conn.execute(
             """
-            SELECT id, email, name, created_at
+            SELECT id, email, name, user_type, created_at
             FROM users
             WHERE id = ?
             """,

--- a/backend/test_pipeline.py
+++ b/backend/test_pipeline.py
@@ -37,8 +37,9 @@ def main() -> None:
     print(f"[test_pipeline] Using video: {video_path}")
 
     try:
-        transcript = process_recording(video_path)
+        transcript, segments = process_recording(video_path)
         print("\n[test_pipeline] ✅ Pipeline completed successfully.")
+        print(f"[test_pipeline] Got {len(segments)} timestamped segments.")
         print("[test_pipeline] Transcript:\n")
         print(transcript)
     except Exception as exc:

--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -52,11 +52,11 @@ export function loginUser(email, password) {
   });
 }
 
-export function registerUser(name, email, password) {
+export function registerUser(name, email, password, userType) {
   return request("/api/auth/register", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, email, password }),
+    body: JSON.stringify({ name, email, password, user_type: userType }),
   });
 }
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -3,6 +3,7 @@ import useAuth from "../hooks/useAuth";
 
 export default function Navbar() {
   const { user, logout } = useAuth();
+  const isProfessor = user?.user_type === "professor";
 
   return (
     <nav>
@@ -10,8 +11,11 @@ export default function Navbar() {
         {user ? (
           <>
             <Link to="/">Dashboard</Link>
-            <Link to="/courses/create">Create Course</Link>
-            <Link to="/courses/join">Join Course</Link>
+            {isProfessor ? (
+              <Link to="/courses/create">Create Course</Link>
+            ) : (
+              <Link to="/courses/join">Join Course</Link>
+            )}
             <Link to="/upload">Upload</Link>
             <Link to="/search">Search</Link>
           </>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,9 +1,36 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import useAuth from "../hooks/useAuth";
+import { getCourses } from "../api/backend";
 
 export default function Navbar() {
   const { user, logout } = useAuth();
   const isProfessor = user?.user_type === "professor";
+  const [canUpload, setCanUpload] = useState(isProfessor);
+
+  useEffect(() => {
+    if (!user) {
+      setCanUpload(false);
+      return;
+    }
+    if (isProfessor) {
+      setCanUpload(true);
+      return;
+    }
+    let cancelled = false;
+    getCourses()
+      .then((payload) => {
+        if (cancelled) return;
+        const eligible = (payload.data || []).some(
+          (c) => c.role === "instructor" || c.role === "ta"
+        );
+        setCanUpload(eligible);
+      })
+      .catch(() => {
+        if (!cancelled) setCanUpload(false);
+      });
+    return () => { cancelled = true; };
+  }, [user, isProfessor]);
 
   return (
     <nav>
@@ -16,7 +43,7 @@ export default function Navbar() {
             ) : (
               <Link to="/courses/join">Join Course</Link>
             )}
-            <Link to="/upload">Upload</Link>
+            {canUpload ? <Link to="/upload">Upload</Link> : null}
             <Link to="/search">Search</Link>
           </>
         ) : (

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -6,17 +6,11 @@ import { getCourses } from "../api/backend";
 export default function Navbar() {
   const { user, logout } = useAuth();
   const isProfessor = user?.user_type === "professor";
-  const [canUpload, setCanUpload] = useState(isProfessor);
+  const [isTaSomewhere, setIsTaSomewhere] = useState(false);
+  const canUpload = Boolean(user) && (isProfessor || isTaSomewhere);
 
   useEffect(() => {
-    if (!user) {
-      setCanUpload(false);
-      return;
-    }
-    if (isProfessor) {
-      setCanUpload(true);
-      return;
-    }
+    if (!user || isProfessor) return;
     let cancelled = false;
     getCourses()
       .then((payload) => {
@@ -24,10 +18,10 @@ export default function Navbar() {
         const eligible = (payload.data || []).some(
           (c) => c.role === "instructor" || c.role === "ta"
         );
-        setCanUpload(eligible);
+        setIsTaSomewhere(eligible);
       })
       .catch(() => {
-        if (!cancelled) setCanUpload(false);
+        if (!cancelled) setIsTaSomewhere(false);
       });
     return () => { cancelled = true; };
   }, [user, isProfessor]);

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -35,8 +35,8 @@ export default function AuthProvider({ children }) {
     return payload;
   }, []);
 
-  const register = useCallback(async (name, email, password) => {
-    const payload = await registerUser(name, email, password);
+  const register = useCallback(async (name, email, password, userType) => {
+    const payload = await registerUser(name, email, password, userType);
     localStorage.setItem("token", payload.data.token);
     setUser(payload.data.user);
     return payload;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -600,6 +600,34 @@ button:disabled {
   color: #2563eb;
 }
 
+.transcript-segments {
+  display: grid;
+  gap: 8px;
+  line-height: 1.65;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.transcript-segments li {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.transcript-timestamp {
+  color: #2563eb;
+  font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.transcript-text {
+  color: #0f172a;
+}
+
 /* --- Utility --- */
 
 .muted-text {

--- a/frontend/src/pages/CreateCourse.jsx
+++ b/frontend/src/pages/CreateCourse.jsx
@@ -1,8 +1,10 @@
 import { useState, useRef, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { createCourse } from "../api/backend";
+import useAuth from "../hooks/useAuth";
 
 export default function CreateCourse() {
+  const { user } = useAuth();
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -15,6 +17,10 @@ export default function CreateCourse() {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
   }, []);
+
+  if (user && user.user_type !== "professor") {
+    return <Navigate to="/" replace />;
+  }
 
   async function handleSubmit(e) {
     e.preventDefault();

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { getCourses, getSessions } from "../api/backend";
+import useAuth from "../hooks/useAuth";
 import {
   getSessionStatusLabel,
   SESSION_STATUS_FILTERS,
 } from "../utils/sessionStatus";
 
 export default function Dashboard() {
+  const { user } = useAuth();
+  const isProfessor = user?.user_type === "professor";
   const [courses, setCourses] = useState([]);
   const [sessions, setSessions] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -98,8 +101,11 @@ export default function Dashboard() {
         <div className="empty-state">
           <p>You are not in any courses yet.</p>
           <div className="empty-state-actions">
-            <Link to="/courses/create" className="btn-link">Create a course</Link>
-            <Link to="/courses/join" className="btn-link btn-link--secondary">Join a course</Link>
+            {isProfessor ? (
+              <Link to="/courses/create" className="btn-link">Create a course</Link>
+            ) : (
+              <Link to="/courses/join" className="btn-link">Join a course</Link>
+            )}
           </div>
         </div>
       ) : (

--- a/frontend/src/pages/JoinCourse.jsx
+++ b/frontend/src/pages/JoinCourse.jsx
@@ -1,12 +1,18 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import { joinCourse } from "../api/backend";
+import useAuth from "../hooks/useAuth";
 
 export default function JoinCourse() {
+  const { user } = useAuth();
   const navigate = useNavigate();
   const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+
+  if (user && user.user_type !== "student") {
+    return <Navigate to="/" replace />;
+  }
 
   async function handleSubmit(e) {
     e.preventDefault();

--- a/frontend/src/pages/Notes.jsx
+++ b/frontend/src/pages/Notes.jsx
@@ -17,6 +17,14 @@ function formatTimestamp(value) {
   return date.toLocaleString();
 }
 
+function formatSegmentTime(seconds) {
+  const total = Math.max(0, Math.floor(Number(seconds) || 0));
+  const hh = String(Math.floor(total / 3600)).padStart(2, "0");
+  const mm = String(Math.floor((total % 3600) / 60)).padStart(2, "0");
+  const ss = String(total % 60).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}
+
 export default function Notes() {
   const { id } = useParams();
   const [loading, setLoading] = useState(true);
@@ -88,6 +96,7 @@ export default function Notes() {
   const KNOWN_STATUSES = Object.keys(SESSION_STATUS_LABELS);
   const topics = notes?.topics || [];
   const actionItems = notes?.action_items || [];
+  const segments = Array.isArray(transcript?.segments) ? transcript.segments : [];
   const hasTranscript = Boolean(transcript?.content);
   const hasNotes = Boolean(notes);
 
@@ -177,7 +186,20 @@ export default function Notes() {
 
         {hasTranscript ? (
           <div className="notes-block">
-            <p>{transcript.content}</p>
+            {segments.length > 0 ? (
+              <ol className="transcript-segments">
+                {segments.map((seg, index) => (
+                  <li key={`${seg.start}-${index}`}>
+                    <span className="transcript-timestamp">
+                      {formatSegmentTime(seg.start)}
+                    </span>
+                    <span className="transcript-text">{seg.text}</span>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p>{transcript.content}</p>
+            )}
           </div>
         ) : status === "uploaded" ? (
           <p className="muted-text">Waiting for processing to start...</p>

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -10,6 +10,7 @@ export default function Register() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [userType, setUserType] = useState("student");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -36,7 +37,7 @@ export default function Register() {
 
     setLoading(true);
     try {
-      await register(name.trim(), email.trim().toLowerCase(), password);
+      await register(name.trim(), email.trim().toLowerCase(), password, userType);
       navigate("/", { replace: true });
     } catch (err) {
       setError(err.message || "Registration failed.");
@@ -88,6 +89,34 @@ export default function Register() {
               disabled={loading}
               autoComplete="new-password"
             />
+          </div>
+
+          <div className="form-field">
+            <label>I am a</label>
+            <div className="user-type-options">
+              <label className="user-type-option">
+                <input
+                  type="radio"
+                  name="user-type"
+                  value="student"
+                  checked={userType === "student"}
+                  onChange={() => setUserType("student")}
+                  disabled={loading}
+                />
+                <span>Student</span>
+              </label>
+              <label className="user-type-option">
+                <input
+                  type="radio"
+                  name="user-type"
+                  value="professor"
+                  checked={userType === "professor"}
+                  onChange={() => setUserType("professor")}
+                  disabled={loading}
+                />
+                <span>Professor</span>
+              </label>
+            </div>
           </div>
 
           <div className="form-field">

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { uploadSession, getCourses } from "../api/backend";
+import useAuth from "../hooks/useAuth";
 
 const ALLOWED_EXTENSIONS = ["mp4", "mp3", "wav", "m4a"];
 
 export default function Upload() {
   const navigate = useNavigate();
   const { id: routeCourseId } = useParams();
+  const { user } = useAuth();
+  const isProfessor = user?.user_type === "professor";
   const [title, setTitle] = useState("");
   const [file, setFile] = useState(null);
   const [courseId, setCourseId] = useState("");
@@ -145,13 +148,17 @@ export default function Upload() {
         <h1>Upload Session</h1>
         <div className="empty-state">
           <p>
-            You need to be an instructor or TA in a course to upload sessions.
+            {isProfessor
+              ? "You need to create a course before uploading recordings."
+              : "Only TAs and instructors can upload recordings. Ask your instructor to promote you to TA."}
           </p>
-          <div className="empty-state-actions">
-            <Link to="/courses/create" className="btn-link">
-              Create a course
-            </Link>
-          </div>
+          {isProfessor ? (
+            <div className="empty-state-actions">
+              <Link to="/courses/create" className="btn-link">
+                Create a course
+              </Link>
+            </div>
+          ) : null}
         </div>
       </div>
     );


### PR DESCRIPTION
## Checklist

- [x] This PR targets `main`.
- [x] I checked that this PR does not accidentally target another feature branch.
- [x] I ran or reviewed the relevant checks for this change.


## Change
  Transcripts now render as timestamped segments (HH:MM:SS in blue, text in black) instead of one paragraph.

##  Backend
  - transcribe_audio now returns (text, segments) — Whisper already produced segments, we were dropping them.
  - New segments JSON column on transcripts + idempotent migration in db.py. content stays as plain text so search keeps working.
  - save_transcript / fetch_transcript_by_session_id handle JSON (de)serialization.

##  Frontend
  - Notes.jsx maps transcript.segments to an <ol> with a formatSegmentTime helper. Falls back to the old paragraph view when segments are missing, so pre-existing transcripts still render.
  - Blue monospace timestamps (tabular-nums) in index.css.

  Granularity is Whisper's native ~5–15s segments. Sentence-level timing would need word_timestamps=True 
  
<img width="2100" height="1690" alt="image" src="https://github.com/user-attachments/assets/66ca8649-5db9-46f3-86f8-0b8e0bdcd101" />
