### PR TITLE
feat(notes): poll session status while processing

### DIFF
--- a/frontend/src/pages/Notes.jsx
+++ b/frontend/src/pages/Notes.jsx
@@ -25,6 +25,9 @@ function formatSegmentTime(seconds) {
   return `${hh}:${mm}:${ss}`;
 }
 
+const TERMINAL_STATUSES = ["notes_generated", "failed"];
+const POLL_INTERVAL_MS = 4000;
+
 export default function Notes() {
   const { id } = useParams();
   const [loading, setLoading] = useState(true);
@@ -35,37 +38,45 @@ export default function Notes() {
 
   useEffect(() => {
     let cancelled = false;
+    let timeoutId = null;
+    let firstLoad = true;
 
     async function loadData() {
-      setLoading(true);
-      setError("");
+      if (firstLoad) {
+        setLoading(true);
+        setError("");
+      }
 
-      try {
-        const results = await Promise.allSettled([
-          getSession(id),
-          getTranscript(id),
-          getNotes(id),
-        ]);
+      const results = await Promise.allSettled([
+        getSession(id),
+        getTranscript(id),
+        getNotes(id),
+      ]);
+      if (cancelled) return;
 
-        if (cancelled) return;
-
-        if (results[0].status === "rejected") {
+      if (results[0].status === "rejected") {
+        if (firstLoad) {
           setError(results[0].reason?.message || "Failed to load session.");
-          return;
+          setLoading(false);
+        } else {
+          timeoutId = setTimeout(loadData, POLL_INTERVAL_MS);
         }
+        return;
+      }
 
-        setSession(results[0].value.data);
+      const sess = results[0].value.data;
+      setSession(sess);
+      if (results[1].status === "fulfilled" && results[1].value?.data) {
+        setTranscript(results[1].value.data);
+      }
+      if (results[2].status === "fulfilled" && results[2].value?.data) {
+        setNotes(results[2].value.data);
+      }
+      if (firstLoad) setLoading(false);
+      firstLoad = false;
 
-        if (results[1].status === "fulfilled") {
-          setTranscript(results[1].value.data);
-        }
-        if (results[2].status === "fulfilled") {
-          setNotes(results[2].value.data);
-        }
-      } catch (err) {
-        if (!cancelled) setError(err.message || "Failed to load notes.");
-      } finally {
-        if (!cancelled) setLoading(false);
+      if (!TERMINAL_STATUSES.includes(sess?.status)) {
+        timeoutId = setTimeout(loadData, POLL_INTERVAL_MS);
       }
     }
 
@@ -73,6 +84,7 @@ export default function Notes() {
 
     return () => {
       cancelled = true;
+      if (timeoutId) clearTimeout(timeoutId);
     };
   }, [id]);
 


### PR DESCRIPTION
### What changed
Notes page now refetches session, transcript, and notes every 4 seconds while the pipeline is running, so content appears without a manual reload. Polling stops once status reaches \`notes_generated\` or \`failed\`, and on unmount.

### How it works
- Same \`Promise.allSettled([getSession, getTranscript, getNotes])\` as before, now called from a recursive \`loadData()\` inside the existing \`useEffect\`.
- \`firstLoad\` flag distinguishes the initial load from poll ticks: initial load flips the loader spinner and surfaces errors; poll ticks stay silent on transient errors and preserve the last-known data.
- Terminal statuses (\`notes_generated\`, \`failed\`) stop the schedule.
- Cleanup cancels in-flight work via the existing \`cancelled\` flag and clears the pending \`setTimeout\`.
- Two small constants hoisted to module scope: \`TERMINAL_STATUSES\` and \`POLL_INTERVAL_MS\` (4000ms).

### What did not change
- No new files.
- No CSS.
- No new state on the component (just closure vars inside the effect).
- Render branches are untouched.
- Backend is untouched.

### Test plan
- [ ] Upload a recording that takes more than a few seconds to process, land on \`/notes/:id\`. Watch the status transition from \`Uploaded\` or \`Processing\` through \`Transcript Ready\` and finally \`Notes Ready\` without a manual reload.
- [ ] Open DevTools Network. Confirm \`GET /api/sessions/:id\`, \`/api/transcripts/:id\`, \`/api/notes/session/:id\` fire every ~4s while non-terminal, and stop after \`notes_generated\`.
- [ ] Open a session already at \`notes_generated\`. Confirm only the initial three fetches, no polling after.
- [ ] Open a \`failed\` session. Confirm no polling.
- [ ] Navigate from one session to another via the course page. No stale error or loading state from the previous session.

### Known limits (not blocking)
- No retry cap. If the backend is down and every tick fails, polling keeps trying forever at 4s.
- 404 on a deleted session also loops forever at 4s until unmount.
- No visibility pause. Background tab still polls at 4s (negligible, one small GET per 4s).
- No manual refresh button.