### PR TITLE
Test/course membership access

### DIFF
--- a/backend/tests/test_course_membership.py
+++ b/backend/tests/test_course_membership.py
@@ -109,6 +109,47 @@ class CourseMembershipTests(unittest.TestCase):
         with patch("middleware.auth.verify_token", return_value=user):
             return self.client.get(path, headers=headers)
 
+    def test_student_can_join_course_with_valid_invite_code(self):
+        """
+        A student with a valid invite code should join as a student member.
+
+        The route should return the course and membership payload and
+        persist a new course_members row in the database.
+        """
+        response = self.post_json(
+            "/api/courses/join",
+            user=self.outsider_user,
+            json={"invite_code": "ALGO01"},
+        )
+
+        self.assertEqual(response.status_code, 201)
+
+        payload = response.get_json()
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["message"], "Joined course successfully")
+
+        data = payload["data"]
+        self.assertEqual(data["course"]["id"], 1)
+        self.assertEqual(data["course"]["name"], "Algorithms")
+        self.assertEqual(data["membership"]["course_id"], 1)
+        self.assertEqual(data["membership"]["user_id"], 3)
+        self.assertEqual(data["membership"]["role"], "student")
+
+        with db.get_connection() as conn:
+            membership = conn.execute(
+                """
+                SELECT course_id, user_id, role
+                FROM course_members
+                WHERE course_id = ? AND user_id = ?
+                """,
+                (1, 3),
+            ).fetchone()
+
+        self.assertIsNotNone(membership)
+        self.assertEqual(membership["course_id"], 1)
+        self.assertEqual(membership["user_id"], 3)
+        self.assertEqual(membership["role"], "student")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_course_membership.py
+++ b/backend/tests/test_course_membership.py
@@ -150,6 +150,66 @@ class CourseMembershipTests(unittest.TestCase):
         self.assertEqual(membership["user_id"], 3)
         self.assertEqual(membership["role"], "student")
 
+    def test_join_course_requires_json_body(self):
+        """Reject join requests that do not send a JSON body."""
+        headers = {"Authorization": "Bearer test-token"}
+
+        with patch("middleware.auth.verify_token", return_value=self.outsider_user):
+            response = self.client.post("/api/courses/join", headers=headers)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "Request body must be JSON")
+
+    def test_join_course_requires_invite_code(self):
+        """Reject join requests with a missing invite code."""
+        response = self.post_json(
+            "/api/courses/join",
+            user=self.outsider_user,
+            json={},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "Invite code required")
+
+    def test_join_course_rejects_invalid_invite_code(self):
+        """Return 404 when the invite code does not match any course."""
+        response = self.post_json(
+            "/api/courses/join",
+            user=self.outsider_user,
+            json={"invite_code": "NOPE99"},
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.get_json()["error"], "Invalid invite code")
+
+    def test_join_course_rejects_existing_member(self):
+        """Return 409 when the user already belongs to the course."""
+        response = self.post_json(
+            "/api/courses/join",
+            user=self.student_user,
+            json={"invite_code": "ALGO01"},
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.get_json()["error"],
+            "User is already a member of this course",
+        )
+
+    def test_join_course_rejects_professor_accounts(self):
+        """Only student accounts should be able to join via invite code."""
+        response = self.post_json(
+            "/api/courses/join",
+            user=self.instructor_user,
+            json={"invite_code": "ALGO01"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.get_json()["error"],
+            "Only student accounts can join courses via invite code",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_course_membership.py
+++ b/backend/tests/test_course_membership.py
@@ -210,6 +210,42 @@ class CourseMembershipTests(unittest.TestCase):
             "Only student accounts can join courses via invite code",
         )
 
+    def test_student_member_can_view_course_details_without_invite_code(self):
+        """Student members should see course details but not the invite code."""
+        response = self.get_json("/api/courses/1", user=self.student_user)
+
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.get_json()
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["message"], "Course retrieved")
+
+        data = payload["data"]
+        self.assertEqual(data["id"], 1)
+        self.assertEqual(data["name"], "Algorithms")
+        self.assertEqual(data["your_role"], "student")
+        self.assertNotIn("invite_code", data)
+
+        member_roles = {member["user_id"]: member["role"] for member in data["members"]}
+        self.assertEqual(member_roles[1], "instructor")
+        self.assertEqual(member_roles[2], "student")
+
+    def test_instructor_member_can_view_course_details_with_invite_code(self):
+        """Instructors should receive the invite code in course details."""
+        response = self.get_json("/api/courses/1", user=self.instructor_user)
+
+        self.assertEqual(response.status_code, 200)
+
+        payload = response.get_json()
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["message"], "Course retrieved")
+
+        data = payload["data"]
+        self.assertEqual(data["id"], 1)
+        self.assertEqual(data["name"], "Algorithms")
+        self.assertEqual(data["your_role"], "instructor")
+        self.assertEqual(data["invite_code"], "ALGO01")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_course_membership.py
+++ b/backend/tests/test_course_membership.py
@@ -44,6 +44,8 @@ class CourseMembershipTests(unittest.TestCase):
         self.app.register_blueprint(courses_bp, url_prefix="/api/courses")
         self.client = self.app.test_client()
 
+        # Keep the shared fixture small: one target course, one outside
+        # course, and just enough users to exercise join/member checks.
         with db.get_connection() as conn:
             conn.executescript(
                 """
@@ -99,6 +101,8 @@ class CourseMembershipTests(unittest.TestCase):
         """Send an authenticated JSON POST request as the given user."""
         headers = {"Authorization": "Bearer test-token"}
 
+        # Patch auth at the middleware boundary so route tests stay
+        # focused on course behavior instead of JWT details.
         with patch("middleware.auth.verify_token", return_value=user):
             return self.client.post(path, json=json, headers=headers)
 
@@ -106,6 +110,8 @@ class CourseMembershipTests(unittest.TestCase):
         """Send an authenticated GET request as the given user."""
         headers = {"Authorization": "Bearer test-token"}
 
+        # Patch auth at the middleware boundary so route tests stay
+        # focused on course behavior instead of JWT details.
         with patch("middleware.auth.verify_token", return_value=user):
             return self.client.get(path, headers=headers)
 

--- a/backend/tests/test_course_membership.py
+++ b/backend/tests/test_course_membership.py
@@ -1,0 +1,114 @@
+"""
+Tests for course membership routes.
+
+This module sets up an isolated Flask app and temporary database for
+course join and membership access tests.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from flask import Flask
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from forum_ai_notetaker import db
+from routes.courses import courses_bp
+
+
+class CourseMembershipTests(unittest.TestCase):
+    """Shared scaffold for course membership route tests."""
+
+    def setUp(self):
+        """
+        Build an isolated app and seed users, courses, and memberships.
+
+        The seed data includes:
+        - one instructor
+        - two student accounts
+        - one course that already has an instructor and one student member
+        - one separate course for non-member access checks
+        """
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.original_db_path = db.DEFAULT_DB_PATH
+        db.DEFAULT_DB_PATH = Path(self.tempdir.name) / "test.sqlite3"
+        db.init_db()
+
+        self.app = Flask(__name__)
+        self.app.config["TESTING"] = True
+        self.app.register_blueprint(courses_bp, url_prefix="/api/courses")
+        self.client = self.app.test_client()
+
+        with db.get_connection() as conn:
+            conn.executescript(
+                """
+                INSERT INTO users (
+                    id, email, name, password_hash, user_type, created_at, updated_at
+                )
+                VALUES
+                    (1, 'teacher@example.com', 'Teacher', 'hash', 'professor', datetime('now'), datetime('now')),
+                    (2, 'student@example.com', 'Student', 'hash', 'student', datetime('now'), datetime('now')),
+                    (3, 'outsider@example.com', 'Outsider', 'hash', 'student', datetime('now'), datetime('now'));
+
+                INSERT INTO courses (id, name, invite_code, created_at, updated_at)
+                VALUES
+                    (1, 'Algorithms', 'ALGO01', datetime('now'), datetime('now')),
+                    (2, 'Databases', 'DATA02', datetime('now'), datetime('now'));
+
+                INSERT INTO course_members (
+                    course_id, user_id, role, created_at, updated_at
+                )
+                VALUES
+                    (1, 1, 'instructor', datetime('now'), datetime('now')),
+                    (1, 2, 'student', datetime('now'), datetime('now')),
+                    (2, 3, 'student', datetime('now'), datetime('now'));
+                """
+            )
+            conn.commit()
+
+        self.instructor_user = {
+            "id": 1,
+            "email": "teacher@example.com",
+            "name": "Teacher",
+            "user_type": "professor",
+        }
+        self.student_user = {
+            "id": 2,
+            "email": "student@example.com",
+            "name": "Student",
+            "user_type": "student",
+        }
+        self.outsider_user = {
+            "id": 3,
+            "email": "outsider@example.com",
+            "name": "Outsider",
+            "user_type": "student",
+        }
+
+    def tearDown(self):
+        """Restore the original database path and remove temp files."""
+        db.DEFAULT_DB_PATH = self.original_db_path
+        self.tempdir.cleanup()
+
+    def post_json(self, path, *, user, json):
+        """Send an authenticated JSON POST request as the given user."""
+        headers = {"Authorization": "Bearer test-token"}
+
+        with patch("middleware.auth.verify_token", return_value=user):
+            return self.client.post(path, json=json, headers=headers)
+
+    def get_json(self, path, *, user):
+        """Send an authenticated GET request as the given user."""
+        headers = {"Authorization": "Bearer test-token"}
+
+        with patch("middleware.auth.verify_token", return_value=user):
+            return self.client.get(path, headers=headers)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_course_membership.py
+++ b/backend/tests/test_course_membership.py
@@ -246,6 +246,23 @@ class CourseMembershipTests(unittest.TestCase):
         self.assertEqual(data["your_role"], "instructor")
         self.assertEqual(data["invite_code"], "ALGO01")
 
+    def test_non_member_cannot_view_course_details(self):
+        """Non-members should be denied access to course detail data."""
+        response = self.get_json("/api/courses/1", user=self.outsider_user)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.get_json()["error"], "Access denied")
+
+    def test_non_member_cannot_view_course_sessions(self):
+        """Non-members should be denied access to the course sessions listing."""
+        response = self.get_json("/api/courses/1/sessions", user=self.outsider_user)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.get_json()["error"],
+            "You are not a member of this course",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_session_upload.py
+++ b/backend/tests/test_session_upload.py
@@ -192,6 +192,44 @@ class SessionUploadTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.get_json()["error"], "course_id is required")
 
+    def test_upload_requires_integer_course_id(self):
+        response = self.post_upload(
+            user=self.instructor_user,
+            course_id="abc",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "course_id must be an integer")
+
+    def test_upload_returns_not_found_for_missing_course(self):
+        response = self.post_upload(
+            user=self.instructor_user,
+            course_id="999",
+        )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.get_json()["error"], "Course not found")
+
+    def test_upload_rejects_students_without_upload_permission(self):
+        response = self.post_upload(
+            user=self.student_user,
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.get_json()["error"],
+            "Only a TA or instructor can upload to this course",
+        )
+
+    def test_upload_rejects_unsupported_file_types(self):
+        response = self.post_upload(
+            user=self.instructor_user,
+            filename="notes.txt",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "Unsupported file type")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_session_upload.py
+++ b/backend/tests/test_session_upload.py
@@ -105,6 +105,52 @@ class SessionUploadTests(unittest.TestCase):
                 content_type="multipart/form-data",
             )
 
+    @patch("routes.sessions.trigger_pipeline")
+    def test_upload_creates_session_saves_file_and_triggers_pipeline(self, mock_trigger_pipeline):
+        response = self.post_upload(
+            user=self.instructor_user,
+            title="Week 1 Lecture",
+            course_id="1",
+            filename="Lecture 1!.MP3",
+        )
+
+        self.assertEqual(response.status_code, 201)
+
+        payload = response.get_json()
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["message"], "Recording uploaded successfully")
+
+        session = payload["data"]
+        self.assertEqual(session["title"], "Week 1 Lecture")
+        self.assertEqual(session["course_id"], 1)
+        self.assertEqual(session["status"], "uploaded")
+        self.assertEqual(session["original_filename"], "Lecture_1.MP3")
+        self.assertTrue(session["stored_path"].startswith("uploads/"))
+
+        stored_filename = Path(session["stored_path"]).name
+        saved_file = Path(self.app.config["UPLOAD_FOLDER"]) / stored_filename
+        self.assertTrue(saved_file.exists())
+        self.assertEqual(saved_file.read_bytes(), b"fake audio bytes")
+
+        with db.get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT title, original_filename, stored_path, status, course_id
+                FROM sessions
+                WHERE id = ?
+                """,
+                (session["id"],),
+            ).fetchone()
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row["title"], "Week 1 Lecture")
+        self.assertEqual(row["original_filename"], "Lecture_1.MP3")
+        self.assertEqual(row["stored_path"], session["stored_path"])
+        self.assertEqual(row["status"], "uploaded")
+        self.assertEqual(row["course_id"], 1)
+
+        mock_trigger_pipeline.assert_called_once_with(session["stored_path"], session["id"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_session_upload.py
+++ b/backend/tests/test_session_upload.py
@@ -151,6 +151,47 @@ class SessionUploadTests(unittest.TestCase):
 
         mock_trigger_pipeline.assert_called_once_with(session["stored_path"], session["id"])
 
+    def test_upload_requires_file_field(self):
+        headers = {"Authorization": "Bearer test-token"}
+
+        with patch("middleware.auth.verify_token", return_value=self.instructor_user):
+            response = self.client.post(
+                "/api/sessions/upload",
+                data={"title": "Week 1 Lecture", "course_id": "1"},
+                headers=headers,
+                content_type="multipart/form-data",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "No file provided")
+
+    def test_upload_rejects_empty_filename(self):
+        response = self.post_upload(
+            user=self.instructor_user,
+            filename="",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "No file selected")
+
+    def test_upload_requires_title(self):
+        response = self.post_upload(
+            user=self.instructor_user,
+            title="",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "Title is required")
+
+    def test_upload_requires_course_id(self):
+        response = self.post_upload(
+            user=self.instructor_user,
+            course_id="",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "course_id is required")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_session_upload.py
+++ b/backend/tests/test_session_upload.py
@@ -1,3 +1,13 @@
+"""
+Tests for the session upload route.
+
+This module exercises the /api/sessions/upload endpoint with an
+isolated Flask app, temporary SQLite database, and temporary upload
+directory. The tests focus on the route's core responsibilities:
+request validation, permission checks, file persistence, and session
+record creation.
+"""
+
 import io
 import sys
 import tempfile
@@ -10,6 +20,10 @@ BACKEND_ROOT = Path(__file__).resolve().parents[1]
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
+# Importing the sessions blueprint pulls in optional runtime
+# dependencies from the processing pipeline. These upload route tests
+# do not need the real implementations, so lightweight stubs keep the
+# module importable in the test environment.
 if "dotenv" not in sys.modules:
     dotenv_module = ModuleType("dotenv")
     dotenv_module.load_dotenv = lambda *args, **kwargs: None
@@ -37,7 +51,18 @@ from routes.sessions import sessions_bp
 
 
 class SessionUploadTests(unittest.TestCase):
+    """Tests for the session upload endpoint."""
+
     def setUp(self):
+        """
+        Build an isolated app and seed the minimum data needed.
+
+        Each test gets:
+        - a temporary SQLite database
+        - a temporary upload folder
+        - one course
+        - one instructor user and one student user in that course
+        """
         self.tempdir = tempfile.TemporaryDirectory()
         self.original_db_path = db.DEFAULT_DB_PATH
         db.DEFAULT_DB_PATH = Path(self.tempdir.name) / "test.sqlite3"
@@ -49,6 +74,8 @@ class SessionUploadTests(unittest.TestCase):
         self.app.register_blueprint(sessions_bp, url_prefix="/api/sessions")
         self.client = self.app.test_client()
 
+        # Seed one upload-capable user and one student so permission
+        # scenarios can reuse the same base fixture.
         with db.get_connection() as conn:
             conn.executescript(
                 """
@@ -86,10 +113,19 @@ class SessionUploadTests(unittest.TestCase):
         }
 
     def tearDown(self):
+        """Restore global DB state and clean up temporary files."""
         db.DEFAULT_DB_PATH = self.original_db_path
         self.tempdir.cleanup()
 
-    def post_upload(self, *, user, title="Week 1 Lecture", course_id="1", filename="lecture.mp3"):
+    def post_upload(
+        self, *, user, title="Week 1 Lecture", course_id="1", filename="lecture.mp3"
+    ):
+        """
+        Send an authenticated multipart upload request as the given user.
+
+        This helper keeps the individual tests focused on one assertion
+        path instead of repeating multipart request setup.
+        """
         data = {
             "title": title,
             "course_id": course_id,
@@ -97,6 +133,7 @@ class SessionUploadTests(unittest.TestCase):
         }
         headers = {"Authorization": "Bearer test-token"}
 
+        # Patch the auth middleware at the import site used by the decorator.
         with patch("middleware.auth.verify_token", return_value=user):
             return self.client.post(
                 "/api/sessions/upload",
@@ -106,7 +143,15 @@ class SessionUploadTests(unittest.TestCase):
             )
 
     @patch("routes.sessions.trigger_pipeline")
-    def test_upload_creates_session_saves_file_and_triggers_pipeline(self, mock_trigger_pipeline):
+    def test_upload_creates_session_saves_file_and_triggers_pipeline(
+        self, mock_trigger_pipeline
+    ):
+        """
+        A valid instructor upload should complete the full route flow.
+
+        The route should sanitize and save the file, create a session
+        row, return a 201 response, and trigger downstream processing.
+        """
         response = self.post_upload(
             user=self.instructor_user,
             title="Week 1 Lecture",
@@ -149,9 +194,12 @@ class SessionUploadTests(unittest.TestCase):
         self.assertEqual(row["status"], "uploaded")
         self.assertEqual(row["course_id"], 1)
 
-        mock_trigger_pipeline.assert_called_once_with(session["stored_path"], session["id"])
+        mock_trigger_pipeline.assert_called_once_with(
+            session["stored_path"], session["id"]
+        )
 
     def test_upload_requires_file_field(self):
+        """Reject requests that omit the multipart file field entirely."""
         headers = {"Authorization": "Bearer test-token"}
 
         with patch("middleware.auth.verify_token", return_value=self.instructor_user):
@@ -166,6 +214,7 @@ class SessionUploadTests(unittest.TestCase):
         self.assertEqual(response.get_json()["error"], "No file provided")
 
     def test_upload_rejects_empty_filename(self):
+        """Reject an upload when the user submits an empty filename."""
         response = self.post_upload(
             user=self.instructor_user,
             filename="",
@@ -175,6 +224,7 @@ class SessionUploadTests(unittest.TestCase):
         self.assertEqual(response.get_json()["error"], "No file selected")
 
     def test_upload_requires_title(self):
+        """Reject an upload when the session title is blank."""
         response = self.post_upload(
             user=self.instructor_user,
             title="",
@@ -184,6 +234,7 @@ class SessionUploadTests(unittest.TestCase):
         self.assertEqual(response.get_json()["error"], "Title is required")
 
     def test_upload_requires_course_id(self):
+        """Reject an upload when course_id is missing from the form data."""
         response = self.post_upload(
             user=self.instructor_user,
             course_id="",
@@ -193,6 +244,7 @@ class SessionUploadTests(unittest.TestCase):
         self.assertEqual(response.get_json()["error"], "course_id is required")
 
     def test_upload_requires_integer_course_id(self):
+        """Reject course_id values that cannot be parsed as integers."""
         response = self.post_upload(
             user=self.instructor_user,
             course_id="abc",
@@ -202,6 +254,7 @@ class SessionUploadTests(unittest.TestCase):
         self.assertEqual(response.get_json()["error"], "course_id must be an integer")
 
     def test_upload_returns_not_found_for_missing_course(self):
+        """Return 404 when the target course does not exist."""
         response = self.post_upload(
             user=self.instructor_user,
             course_id="999",
@@ -211,6 +264,7 @@ class SessionUploadTests(unittest.TestCase):
         self.assertEqual(response.get_json()["error"], "Course not found")
 
     def test_upload_rejects_students_without_upload_permission(self):
+        """Reject student uploads because only TAs and instructors may upload."""
         response = self.post_upload(
             user=self.student_user,
         )
@@ -222,6 +276,7 @@ class SessionUploadTests(unittest.TestCase):
         )
 
     def test_upload_rejects_unsupported_file_types(self):
+        """Reject files whose extensions are not in the allowed upload list."""
         response = self.post_upload(
             user=self.instructor_user,
             filename="notes.txt",

--- a/backend/tests/test_session_upload.py
+++ b/backend/tests/test_session_upload.py
@@ -1,0 +1,110 @@
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+if "dotenv" not in sys.modules:
+    dotenv_module = ModuleType("dotenv")
+    dotenv_module.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = dotenv_module
+
+if "groq" not in sys.modules:
+    groq_module = ModuleType("groq")
+
+    class _Groq:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    groq_module.Groq = _Groq
+    sys.modules["groq"] = groq_module
+
+if "whisper" not in sys.modules:
+    whisper_module = ModuleType("whisper")
+    whisper_module.load_model = lambda *args, **kwargs: None
+    sys.modules["whisper"] = whisper_module
+
+from flask import Flask
+
+from forum_ai_notetaker import db
+from routes.sessions import sessions_bp
+
+
+class SessionUploadTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.original_db_path = db.DEFAULT_DB_PATH
+        db.DEFAULT_DB_PATH = Path(self.tempdir.name) / "test.sqlite3"
+        db.init_db()
+
+        self.app = Flask(__name__)
+        self.app.config["TESTING"] = True
+        self.app.config["UPLOAD_FOLDER"] = str(Path(self.tempdir.name) / "uploads")
+        self.app.register_blueprint(sessions_bp, url_prefix="/api/sessions")
+        self.client = self.app.test_client()
+
+        with db.get_connection() as conn:
+            conn.executescript(
+                """
+                INSERT INTO users (
+                    id, email, name, password_hash, user_type, created_at, updated_at
+                )
+                VALUES
+                    (1, 'teacher@example.com', 'Teacher', 'hash', 'professor', datetime('now'), datetime('now')),
+                    (2, 'student@example.com', 'Student', 'hash', 'student', datetime('now'), datetime('now'));
+
+                INSERT INTO courses (id, name, invite_code, created_at, updated_at)
+                VALUES (1, 'Algorithms', 'ALGO01', datetime('now'), datetime('now'));
+
+                INSERT INTO course_members (
+                    course_id, user_id, role, created_at, updated_at
+                )
+                VALUES
+                    (1, 1, 'instructor', datetime('now'), datetime('now')),
+                    (1, 2, 'student', datetime('now'), datetime('now'));
+                """
+            )
+            conn.commit()
+
+        self.instructor_user = {
+            "id": 1,
+            "email": "teacher@example.com",
+            "name": "Teacher",
+            "user_type": "professor",
+        }
+        self.student_user = {
+            "id": 2,
+            "email": "student@example.com",
+            "name": "Student",
+            "user_type": "student",
+        }
+
+    def tearDown(self):
+        db.DEFAULT_DB_PATH = self.original_db_path
+        self.tempdir.cleanup()
+
+    def post_upload(self, *, user, title="Week 1 Lecture", course_id="1", filename="lecture.mp3"):
+        data = {
+            "title": title,
+            "course_id": course_id,
+            "file": (io.BytesIO(b"fake audio bytes"), filename),
+        }
+        headers = {"Authorization": "Bearer test-token"}
+
+        with patch("middleware.auth.verify_token", return_value=user):
+            return self.client.post(
+                "/api/sessions/upload",
+                data=data,
+                headers=headers,
+                content_type="multipart/form-data",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR adds route-level backend test coverage for course membership workflows. It covers joining a course by invite code, validating join failures, returning course details to members, and rejecting non-members from protected course endpoints.

## What’s Included

- Added backend/tests/test_course_membership.py
- Added isolated test scaffolding with:
temporary SQLite database
minimal Flask app registering courses_bp
seeded users, courses, and course memberships
authenticated request helpers for JSON POST and GET
- Added join-course success coverage for:
POST /api/courses/join
valid student invite-code join
persisted course_members row with student role
- Added join-course validation/conflict coverage for:
missing JSON body
missing invite code
invalid invite code
already-member join attempt
professor account attempting to join via invite code
- Added member access coverage for:
student viewing GET /api/courses/<course_id> without invite_code
instructor viewing GET /api/courses/<course_id> with invite_code
- Added non-member rejection coverage for:
GET /api/courses/<course_id>
GET /api/courses/<course_id>/sessions

Why
These routes enforce key course membership and access rules. Adding tests here helps prevent regressions in:

- invite-based course joining
- membership checks
- role-based response shaping
- non-member access protection

## Testing
python -m unittest backend.tests.test_course_membership