### PR TITLE
Fix/long transcripts

### DIFF
--- a/backend/forum_ai_notetaker/db.py
+++ b/backend/forum_ai_notetaker/db.py
@@ -15,6 +15,44 @@ def _column_exists(connection: sqlite3.Connection, table_name: str, column_name:
     return any(row[1] == column_name for row in rows)
 
 
+def _sessions_status_check_includes(connection: sqlite3.Connection, value: str) -> bool:
+    row = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'sessions'"
+    ).fetchone()
+    return bool(row) and value in (row[0] or "")
+
+
+def _migrate_sessions_status_check(connection: sqlite3.Connection) -> None:
+    """
+    Rebuild the sessions table so the status CHECK constraint accepts
+    'notes_failed'. SQLite cannot alter a CHECK in place, so we copy
+    the data through a temporary table.
+    """
+    connection.executescript(
+        """
+        CREATE TABLE sessions_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            original_filename TEXT NOT NULL,
+            stored_path TEXT NOT NULL UNIQUE,
+            status TEXT NOT NULL DEFAULT 'uploaded'
+                CHECK (status IN ('uploaded', 'processing', 'transcribed', 'notes_generated', 'notes_failed', 'failed')),
+            course_id INTEGER DEFAULT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE SET NULL
+        );
+        INSERT INTO sessions_new (id, title, original_filename, stored_path, status, course_id, created_at, updated_at)
+            SELECT id, title, original_filename, stored_path, status, course_id, created_at, updated_at FROM sessions;
+        DROP TABLE sessions;
+        ALTER TABLE sessions_new RENAME TO sessions;
+        CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+        CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);
+        CREATE INDEX IF NOT EXISTS idx_sessions_course_id ON sessions(course_id);
+        """
+    )
+
+
 def _run_migrations(connection: sqlite3.Connection) -> None:
     if not _column_exists(connection, "sessions", "course_id"):
         connection.execute(
@@ -39,6 +77,9 @@ def _run_migrations(connection: sqlite3.Connection) -> None:
             "ALTER TABLE transcripts "
             "ADD COLUMN segments TEXT NOT NULL DEFAULT '[]'"
         )
+
+    if not _sessions_status_check_includes(connection, "notes_failed"):
+        _migrate_sessions_status_check(connection)
 
 
 def resolve_db_path(db_path: str | Path | None = None) -> Path:

--- a/backend/forum_ai_notetaker/schema.sql
+++ b/backend/forum_ai_notetaker/schema.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     original_filename TEXT NOT NULL,
     stored_path TEXT NOT NULL UNIQUE,
     status TEXT NOT NULL DEFAULT 'uploaded'
-        CHECK (status IN ('uploaded', 'processing', 'transcribed', 'notes_generated', 'failed')),
+        CHECK (status IN ('uploaded', 'processing', 'transcribed', 'notes_generated', 'notes_failed', 'failed')),
     course_id INTEGER DEFAULT NULL,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,

--- a/backend/pipeline/trigger.py
+++ b/backend/pipeline/trigger.py
@@ -11,10 +11,7 @@ from pathlib import Path
 
 from pipeline.audio import extract_audio
 from pipeline.transcribe import transcribe_audio
-from services.groq_service import (
-    generate_fallback_notes,
-    generate_notes_from_transcript,
-)
+from services.groq_service import generate_notes_from_transcript
 from services.note_service import save_notes
 from services.session_service import update_session_status
 from services.transcript_service import save_transcript
@@ -57,10 +54,11 @@ def trigger_pipeline(file_path: str, session_id: int) -> None:
             notes = generate_notes_from_transcript(transcript_text)
         except Exception:
             logger.exception(
-                "Groq note generation failed for session %s. Using fallback summary generation.",
-                session_id,
+                "Groq note generation failed for session %s", session_id
             )
-            notes = generate_fallback_notes(transcript_text)
+            print(f"[STATUS] Session {session_id} → notes_failed")
+            update_session_status(session_id, "notes_failed")
+            return
 
         save_notes(
             session_id,

--- a/backend/services/groq_service.py
+++ b/backend/services/groq_service.py
@@ -5,6 +5,7 @@ Handles note generation from a transcript using the Groq API.
 """
 
 import json
+import logging
 import os
 import re
 
@@ -12,6 +13,13 @@ from dotenv import load_dotenv
 from groq import Groq
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# Keep each Groq request well under the 12,000 TPM on_demand tier.
+# Groq's tokenizer runs ~4 chars/token on English transcripts, so 20k chars
+# ≈ 5k tokens of transcript plus a small scaffolding overhead per call.
+_MAX_TRANSCRIPT_CHARS_PER_CHUNK = 20_000
 
 
 def _validate_notes_payload(payload: dict) -> dict:
@@ -40,42 +48,71 @@ def _validate_notes_payload(payload: dict) -> dict:
     }
 
 
-def generate_fallback_notes(transcript_text: str) -> dict:
+def _split_transcript_into_chunks(
+    transcript_text: str, max_chars: int = _MAX_TRANSCRIPT_CHARS_PER_CHUNK
+) -> list[str]:
     """
-    Generate a basic summary when Groq note generation fails.
+    Split a transcript into chunks that each fit under the Groq TPM budget.
+
+    Splits prefer paragraph boundaries, then sentence boundaries, so chunks
+    stay semantically coherent for the per-chunk summarization step.
     """
-    paragraphs = [paragraph.strip() for paragraph in transcript_text.splitlines() if paragraph.strip()]
-    summary_sentences = []
+    if len(transcript_text) <= max_chars:
+        return [transcript_text]
+
+    paragraphs = re.split(r"\n\s*\n", transcript_text.strip())
+    chunks: list[str] = []
+    current = ""
 
     for paragraph in paragraphs:
-        sentence_parts = re.split(r"(?<=[.!?])\s+", paragraph, maxsplit=1)
-        first_sentence = sentence_parts[0].strip()
-        if first_sentence and first_sentence[-1] not in ".!?":
-            first_sentence = f"{first_sentence}."
-        if first_sentence:
-            summary_sentences.append(first_sentence)
+        paragraph = paragraph.strip()
+        if not paragraph:
+            continue
 
-    summary = " ".join(summary_sentences).strip()
-    if not summary:
-        summary = transcript_text.strip()
+        candidate = f"{current}\n\n{paragraph}" if current else paragraph
 
-    return {
-        "summary": summary,
-        "topics": [],
-        "action_items": [],
-    }
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+
+        if current:
+            chunks.append(current)
+            current = ""
+
+        if len(paragraph) <= max_chars:
+            current = paragraph
+            continue
+
+        # A single paragraph exceeds the budget — break it at sentence ends.
+        sentences = re.split(r"(?<=[.!?])\s+", paragraph)
+        for sentence in sentences:
+            sentence = sentence.strip()
+            if not sentence:
+                continue
+
+            candidate = f"{current} {sentence}".strip() if current else sentence
+            if len(candidate) <= max_chars:
+                current = candidate
+                continue
+
+            if current:
+                chunks.append(current)
+            # Sentence itself may still exceed the cap; hard-split as a last resort.
+            while len(sentence) > max_chars:
+                chunks.append(sentence[:max_chars])
+                sentence = sentence[max_chars:]
+            current = sentence
+
+    if current:
+        chunks.append(current)
+
+    return chunks
 
 
-def generate_notes_from_transcript(transcript_text: str) -> dict:
+def _call_groq_for_chunk(client: Groq, chunk_text: str) -> dict:
     """
-    Generate structured notes from a transcript using Groq.
+    Run one Groq completion over a single transcript chunk.
     """
-    api_key = os.environ.get("GROQ_API_KEY")
-    if not api_key:
-        raise RuntimeError("GROQ_API_KEY is not set")
-
-    client = Groq(api_key=api_key)
-
     response = client.chat.completions.create(
         model="llama-3.3-70b-versatile",
         messages=[
@@ -94,7 +131,7 @@ def generate_notes_from_transcript(transcript_text: str) -> dict:
                     '  "topics": ["string"],\n'
                     '  "action_items": ["string"]\n'
                     "}\n\n"
-                    f"Transcript:\n{transcript_text}"
+                    f"Transcript:\n{chunk_text}"
                 ),
             },
         ],
@@ -104,3 +141,59 @@ def generate_notes_from_transcript(transcript_text: str) -> dict:
     content = response.choices[0].message.content
     payload = json.loads(content)
     return _validate_notes_payload(payload)
+
+
+def _dedupe_preserving_order(items: list[str]) -> list[str]:
+    """
+    Remove case-insensitive duplicates while preserving first-seen order.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        key = item.strip().lower()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        result.append(item.strip())
+    return result
+
+
+def _merge_chunk_notes(chunk_notes: list[dict]) -> dict:
+    """
+    Combine per-chunk note payloads into a single notes payload.
+    """
+    summaries = [note["summary"].strip() for note in chunk_notes if note["summary"].strip()]
+    topics: list[str] = []
+    action_items: list[str] = []
+
+    for note in chunk_notes:
+        topics.extend(note["topics"])
+        action_items.extend(note["action_items"])
+
+    return {
+        "summary": "\n\n".join(summaries),
+        "topics": _dedupe_preserving_order(topics),
+        "action_items": _dedupe_preserving_order(action_items),
+    }
+
+
+def generate_notes_from_transcript(transcript_text: str) -> dict:
+    """
+    Generate structured notes from a transcript using Groq.
+
+    Long transcripts are split into chunks that each fit under the Groq
+    per-minute token budget; per-chunk results are merged before return.
+    """
+    api_key = os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError("GROQ_API_KEY is not set")
+
+    client = Groq(api_key=api_key)
+    chunks = _split_transcript_into_chunks(transcript_text)
+
+    if len(chunks) == 1:
+        return _call_groq_for_chunk(client, chunks[0])
+
+    logger.info("Transcript too long for one Groq call; splitting into %d chunks", len(chunks))
+    chunk_notes = [_call_groq_for_chunk(client, chunk) for chunk in chunks]
+    return _merge_chunk_notes(chunk_notes)

--- a/backend/services/groq_service.py
+++ b/backend/services/groq_service.py
@@ -136,11 +136,33 @@ def _call_groq_for_chunk(client: Groq, chunk_text: str) -> dict:
             },
         ],
         temperature=0.2,
+        response_format={"type": "json_object"},
     )
 
     content = response.choices[0].message.content
-    payload = json.loads(content)
+    try:
+        payload = json.loads(_strip_json_fences(content))
+    except (json.JSONDecodeError, TypeError):
+        logger.error(
+            "Groq returned non-JSON content. finish_reason=%s raw=%r",
+            getattr(response.choices[0], "finish_reason", None),
+            content,
+        )
+        raise
     return _validate_notes_payload(payload)
+
+
+_JSON_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.IGNORECASE)
+
+
+def _strip_json_fences(content: str | None) -> str:
+    """
+    Remove ```json ... ``` fences that models sometimes wrap JSON in,
+    even when asked for raw JSON.
+    """
+    if not content:
+        return ""
+    return _JSON_FENCE_RE.sub("", content).strip()
 
 
 def _dedupe_preserving_order(items: list[str]) -> list[str]:

--- a/backend/services/groq_service.py
+++ b/backend/services/groq_service.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+from typing import Optional
 
 from dotenv import load_dotenv
 from groq import Groq
@@ -155,7 +156,7 @@ def _call_groq_for_chunk(client: Groq, chunk_text: str) -> dict:
 _JSON_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.IGNORECASE)
 
 
-def _strip_json_fences(content: str | None) -> str:
+def _strip_json_fences(content: Optional[str]) -> str:
     """
     Remove ```json ... ``` fences that models sometimes wrap JSON in,
     even when asked for raw JSON.

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -55,7 +55,9 @@ export default function Dashboard() {
     const ready = sessions.filter(
       (s) => s.status === "transcribed" || s.status === "notes_generated"
     ).length;
-    const failed = sessions.filter((s) => s.status === "failed").length;
+    const failed = sessions.filter(
+      (s) => s.status === "failed" || s.status === "notes_failed"
+    ).length;
     return { total, ready, failed };
   }, [sessions]);
 

--- a/frontend/src/pages/Notes.jsx
+++ b/frontend/src/pages/Notes.jsx
@@ -175,6 +175,14 @@ export default function Notes() {
         </p>
       ) : null}
 
+      {status === "notes_failed" ? (
+        <p className="error-text" role="alert">
+          We couldn&apos;t generate notes for this transcript. This often happens
+          with very long recordings that exceed the note-generation token budget.
+          The transcript is still available below.
+        </p>
+      ) : null}
+
       <section className="notes-section">
         <h2 className="section-heading">Study Notes</h2>
 

--- a/frontend/src/utils/sessionStatus.js
+++ b/frontend/src/utils/sessionStatus.js
@@ -3,6 +3,7 @@ export const SESSION_STATUS_LABELS = {
   processing: "Processing",
   transcribed: "Transcript Ready",
   notes_generated: "Notes Ready",
+  notes_failed: "Notes Failed",
   failed: "Failed",
 };
 
@@ -11,6 +12,7 @@ export const SESSION_STATUS_FILTERS = [
   { value: "processing", label: "Processing" },
   { value: "transcribed", label: "Transcript Ready" },
   { value: "notes_generated", label: "Notes Ready" },
+  { value: "notes_failed", label: "Notes Failed" },
   { value: "failed", label: "Failed" },
 ];
 


### PR DESCRIPTION
## Checklist

- [x] This PR targets `main`.
- [x] I checked that this PR does not accidentally target another feature branch.
- [x] I ran or reviewed the relevant checks for this change.

## Summary
  Fixes Issue #52: long transcripts no longer silently produce empty notes.

  - Chunk transcripts over ~20k chars into multiple Groq calls and merge (concat summaries, dedupe topics/action_items).
  - Replace silent fallback with a new `notes_failed` status so failures surface in the UI instead of saving garbage.
  - Harden the Groq call: `response_format={"type":"json_object"}`, strip stray ```json fences, log raw content + finish_reason on parse failure.
  - Add a SQLite migration that rebuilds the `sessions` table so existing DBs accept the new status.

  ## Test plan
  - [ ] Upload a short recording → notes generate normally.
  - [ ] Upload a long (>30k-char transcript) recording → chunked call succeeds, notes populated.
  - [ ] Force a Groq failure → session shows `notes_failed` banner on the Notes page, transcript still viewable.
  - [ ] Restart backend against an existing DB → migration runs, `notes_failed` inserts succeed.
<img width="641" height="860" alt="image" src="https://github.com/user-attachments/assets/44739ef7-4706-4515-a87f-d24084621df0" />
