### PR TITLE
fix: make session search demo-ready

### DIFF
--- a/backend/services/search_service.py
+++ b/backend/services/search_service.py
@@ -96,8 +96,10 @@ def _build_result(session: dict, query: str) -> dict:
         notes_snippet = _make_snippet(combined_notes, query)
 
     return {
+        "id": session["id"],
         "session_id": session["id"],
         "title": title,
+        "original_filename": session.get("original_filename"),
         "course_id": session.get("course_id"),
         "status": session.get("status"),
         "matched_in": matched_in,

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -3,6 +3,14 @@ import { Link } from "react-router-dom";
 import { searchSessions } from "../api/backend";
 import { getSessionStatusLabel } from "../utils/sessionStatus";
 
+function formatMatchLocations(matchedIn) {
+  if (!Array.isArray(matchedIn) || matchedIn.length === 0) {
+    return "session";
+  }
+
+  return matchedIn.join(", ");
+}
+
 export default function Search() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState([]);
@@ -65,15 +73,29 @@ export default function Search() {
       {results.length > 0 ? (
         <ul className="session-list">
           {results.map((session) => (
-            <li className="session-card" key={session.id}>
+            <li
+              className="session-card"
+              key={session.session_id ?? session.id}
+            >
               <div>
                 <strong>{session.title}</strong>
                 <p className="muted-text">{session.original_filename}</p>
                 <p className="muted-text">
                   Status: {getSessionStatusLabel(session.status)}
                 </p>
+                <p className="muted-text">
+                  Match found in: {formatMatchLocations(session.matched_in)}
+                </p>
+                {session.transcript_snippet ? (
+                  <p className="muted-text">{session.transcript_snippet}</p>
+                ) : null}
+                {session.notes_snippet ? (
+                  <p className="muted-text">{session.notes_snippet}</p>
+                ) : null}
               </div>
-              <Link to={`/notes/${session.id}`}>View transcript/notes</Link>
+              <Link to={`/notes/${session.session_id ?? session.id}`}>
+                View transcript/notes
+              </Link>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## What changed
- fixed session search result links so they open the correct notes/transcript page
- aligned backend search payload with frontend expectations
- added match-source and snippet display to search results for clearer UX

## Why
The search flow is part of the final demo, so it needs to work reliably for reviewers and for the final recording.

## How to test
- run `npm run lint` in `frontend/`
- run `python3 -m unittest backend/tests/test_session_search.py`
- log in, open `/search`, search for a known transcript phrase, and confirm `View transcript/notes` opens the correct session