### PR TITLE
fix: keep auth working on clean setups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-# Copy this file to .env and fill in the value.
-# If left blank, note generation falls back to a local heuristic summary
-# so the app still works end-to-end without a Groq account.
+# Copy this file to .env to override the local/demo defaults.
+# If GROQ_API_KEY is left blank, note generation falls back to a local
+# heuristic summary so the app still works end-to-end without a Groq account.
+# JWT_SECRET_KEY is optional for local use because the app falls back to a
+# bundled dev secret, but set your own value for shared deployments.
+JWT_SECRET_KEY=change-me-for-shared-deployments
 GROQ_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ docker compose up --build
 - Frontend: http://localhost:5173
 - Backend API: http://localhost:5000
 
-The Groq API key is **provided separately** with the assignment submission — no signup needed. If `.env` is empty or missing, the app still works end-to-end: note generation falls back to a local heuristic summary instead of calling Groq.
+The Groq API key is **provided separately** with the assignment submission — no signup needed. If `.env` is empty or missing, the app still works end-to-end:
+- authentication falls back to a bundled local JWT secret for signup/login
+- note generation falls back to a local heuristic summary instead of calling Groq
 
 ### Architecture
 
@@ -72,6 +74,7 @@ python app.py
 ```
 
 The server runs at `http://127.0.0.1:5000`. The database is auto-initialized on startup.
+For local manual runs, `JWT_SECRET_KEY` is optional; if omitted, the app uses the same bundled dev secret as Docker.
 
 ### Frontend
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -29,7 +29,7 @@ Upload recording -> Extract audio -> Transcribe with Whisper -> Save transcript 
 1. Create and activate a virtual environment.
 2. Install dependencies from `requirements.txt`.
 3. Install `openai-whisper` if it is not already available in your environment.
-4. Add required environment variables in `backend/.env`.
+4. Add environment variables in `backend/.env` if you want to override local defaults.
 5. Start the Flask server.
 
 Example:
@@ -43,9 +43,10 @@ pip install openai-whisper
 python app.py
 ```
 
-Required environment variables:
+Environment variables:
 
-- `GROQ_API_KEY` - used to generate notes from transcripts with Groq
+- `JWT_SECRET_KEY` - optional for local use; if omitted, auth falls back to a bundled dev secret
+- `GROQ_API_KEY` - optional; if omitted, notes fall back to the local heuristic summary flow
 
 ---
 

--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from flask import Flask
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from forum_ai_notetaker import db
+from routes.auth import auth_bp
+from utils.auth import verify_token
+
+
+class AuthRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.original_db_path = db.DEFAULT_DB_PATH
+        db.DEFAULT_DB_PATH = Path(self.tempdir.name) / "test.sqlite3"
+        db.init_db()
+
+        self.app = Flask(__name__)
+        self.app.config["TESTING"] = True
+        self.app.register_blueprint(auth_bp, url_prefix="/api/auth")
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        db.DEFAULT_DB_PATH = self.original_db_path
+        self.tempdir.cleanup()
+
+    def test_register_succeeds_without_jwt_secret_env(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JWT_SECRET_KEY", None)
+
+            response = self.client.post(
+                "/api/auth/register",
+                json={
+                    "email": "student@example.com",
+                    "name": "Student",
+                    "password": "password123",
+                    "user_type": "student",
+                },
+            )
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.get_json()
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["message"], "User registered successfully")
+
+        token = payload["data"]["token"]
+        user = payload["data"]["user"]
+
+        decoded = verify_token(token)
+
+        self.assertEqual(user["email"], "student@example.com")
+        self.assertEqual(user["user_type"], "student")
+        self.assertEqual(decoded["email"], "student@example.com")
+        self.assertEqual(decoded["user_id"], user["id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/utils/auth.py
+++ b/backend/utils/auth.py
@@ -10,8 +10,19 @@ from datetime import datetime, timezone, timedelta
 import jwt
 
 
-SECRET_KEY = os.environ.get("JWT_SECRET_KEY")
+DEFAULT_SECRET_KEY = "forum-ai-notetaker-local-dev-jwt-secret"
 EXPIRY_HOURS = int(os.environ.get("JWT_EXPIRY_HOURS", "24"))
+
+
+def _get_secret_key() -> str:
+    """
+    Return the JWT signing key.
+
+    For local/demo environments we allow a built-in fallback so a clean
+    checkout can still sign up and log in without extra manual setup.
+    Deployments can override this by setting JWT_SECRET_KEY explicitly.
+    """
+    return os.environ.get("JWT_SECRET_KEY") or DEFAULT_SECRET_KEY
 
 
 def generate_token(user_id: int, email: str) -> str:
@@ -21,9 +32,6 @@ def generate_token(user_id: int, email: str) -> str:
     The token contains the user_id, email, issued-at time,
     and an expiry timestamp.
     """
-    if not SECRET_KEY:
-        raise RuntimeError("JWT_SECRET_KEY is not set in environment")
-
     now = datetime.now(timezone.utc)
     payload = {
         "user_id": user_id,
@@ -31,7 +39,7 @@ def generate_token(user_id: int, email: str) -> str:
         "iat": now,
         "exp": now + timedelta(hours=EXPIRY_HOURS),
     }
-    return jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+    return jwt.encode(payload, _get_secret_key(), algorithm="HS256")
 
 
 def verify_token(token: str) -> dict:
@@ -41,7 +49,4 @@ def verify_token(token: str) -> dict:
     Raises jwt.ExpiredSignatureError if the token has expired.
     Raises jwt.InvalidTokenError for any other validation failure.
     """
-    if not SECRET_KEY:
-        raise RuntimeError("JWT_SECRET_KEY is not set in environment")
-
-    return jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+    return jwt.decode(token, _get_secret_key(), algorithms=["HS256"])


### PR DESCRIPTION
## What changed
- added a bundled local JWT fallback so signup/login work even when `JWT_SECRET_KEY` is not set
- documented the JWT behavior in `.env.example`, the root README, and the backend README
- added an auth route regression test covering student registration without a JWT secret in the environment

## Why
During demo prep, creating a student account on a clean setup returned a 500. The request reached `/api/auth/register`, created the user row, and then crashed while trying to mint the JWT because `JWT_SECRET_KEY` was missing from the environment. That makes fresh Docker setups fragile for reviewers and for the final demo.

## How to test
- run `python3 -m unittest backend/tests/test_session_search.py`
- run `python3 -m unittest backend/tests/test_schema_integrity.py`
- run `docker run --rm -v "$PWD/backend:/app/backend" -w /app/backend forum-ai-notetaker-backend python -m unittest discover -s tests -p "test_auth_routes.py"`
- start from a clean local setup and confirm student signup/login works without manually creating `.env`