### PR TITLE
Prepare backend and frontend for Railway deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,34 @@
-# Copy this file to .env and fill in the value.
+# Copy this file to .env and fill in the values.
+
+# --- AI ---
 # If left blank, note generation falls back to a local heuristic summary
 # so the app still works end-to-end without a Groq account.
-GROQ_API_KEY=your_key_here
+GROQ_API_KEY=CHANGE_ME
+
+# --- Security ---
+# Required in production. If unset, the app refuses to boot (to prevent the
+# dev-secret-key fallback in backend/utils/auth.py from signing real tokens).
+# Generate with: openssl rand -hex 32
+JWT_SECRET_KEY=CHANGE_ME
+JWT_EXPIRY_HOURS=168
+
+# Gate for professor self-registration. Without this, anyone hitting the
+# public URL could create a professor account. If unset, registration is
+# open (acceptable for local dev). Generate with: openssl rand -hex 16
+PROFESSOR_REGISTRATION_SECRET=CHANGE_ME
+
+# --- Deployment ---
+# Port the Flask/gunicorn server binds to. Railway injects this automatically.
+PORT=5000
+
+# Absolute path to the SQLite database file. Point at a mounted volume in
+# production so data survives redeploys.
+DATABASE_PATH=/app/data/forum_ai_notetaker.sqlite3
+
+# Absolute path to uploaded recordings. Point at a mounted volume in prod.
+UPLOAD_FOLDER=/app/backend/uploads
+
+# Comma-separated list of allowed frontend origins. Use * for local dev.
+# In production set this to the deployed frontend URL, e.g.
+# https://frontend-production-xxxx.up.railway.app
+CORS_ORIGINS=*

--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,12 @@ test.mp3
 myenv/
 
 *.db
+*.db-wal
+*.db-shm
 *.sqlite
 *.sqlite3
+*.sqlite3-wal
+*.sqlite3-shm
 myenv
 
 # Test media files
@@ -28,3 +32,9 @@ myenv
 *.mp4
 *.wav
 *.m4a
+
+# Private workspace and local tooling noise
+local-work/
+.serena/
+*.log
+*.excalidraw

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,4 +32,4 @@ WORKDIR /app/backend
 
 EXPOSE 5000
 
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "--threads", "4", "--timeout", "600", "app:app"]
+CMD gunicorn --bind 0.0.0.0:${PORT:-5000} --workers 1 --threads 2 --timeout 1800 app:app

--- a/backend/app.py
+++ b/backend/app.py
@@ -22,6 +22,7 @@ to assemble the application and wire together all components in a
 centralized and maintainable way.
 """
 
+import os
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -60,18 +61,51 @@ def create_app() -> Flask:
     """
     app = Flask(__name__)
 
-    # Enable cross-origin requests so the React frontend can
-    # communicate with the backend during development.
-    CORS(app)
+    # Refuse to boot in production with a placeholder/fallback secret.
+    # utils/auth.py falls back to "dev-secret-key" (in the public repo) if
+    # JWT_SECRET_KEY is unset; .env.example ships "CHANGE_ME". Block both.
+    # Detection: Railway reliably injects RAILWAY_ENVIRONMENT; FLASK_ENV was
+    # removed in Flask 2.3 and cannot be relied on.
+    is_production = bool(os.environ.get("RAILWAY_ENVIRONMENT"))
+    weak_secrets = {"", "dev-secret-key", "CHANGE_ME"}
+    if is_production:
+        if os.environ.get("JWT_SECRET_KEY", "") in weak_secrets:
+            raise RuntimeError(
+                "JWT_SECRET_KEY must be set to a real value in production "
+                "(not blank, not 'dev-secret-key', not 'CHANGE_ME')"
+            )
+        # Professor-registration gate is a no-op if the secret is missing,
+        # so require it explicitly in prod to avoid silent open registration.
+        if os.environ.get("PROFESSOR_REGISTRATION_SECRET", "") in weak_secrets:
+            raise RuntimeError(
+                "PROFESSOR_REGISTRATION_SECRET must be set in production"
+            )
+
+    # Cap upload size at the Flask layer. nginx on the frontend has a 500M
+    # cap but direct POSTs to the backend public URL bypass nginx entirely.
+    app.config["MAX_CONTENT_LENGTH"] = 500 * 1024 * 1024
+
+    # CORS is env-driven. Pass "*" as a literal string (not ["*"]) because
+    # flask-cors treats them differently on credentialed requests.
+    raw_origins = os.environ.get("CORS_ORIGINS", "*").strip()
+    cors_origins: object
+    if raw_origins == "*":
+        cors_origins = "*"
+    else:
+        cors_origins = [o.strip() for o in raw_origins.split(",") if o.strip()]
+    CORS(
+        app,
+        resources={r"/api/*": {"origins": cors_origins}},
+        expose_headers=["Content-Range", "Accept-Ranges", "Content-Length"],
+    )
 
     # Create database tables if they do not exist yet.
     init_db()
     recover_interrupted_processing_sessions()
 
-    # Resolve upload directory from the backend root so it stays stable
-    # regardless of the process working directory.
+    # Upload directory is env-overridable so it can point at a Railway volume.
     backend_root = Path(__file__).resolve().parent
-    upload_folder = backend_root / "uploads"
+    upload_folder = Path(os.environ.get("UPLOAD_FOLDER", str(backend_root / "uploads")))
     upload_folder.mkdir(parents=True, exist_ok=True)
     app.config["UPLOAD_FOLDER"] = str(upload_folder)
 

--- a/backend/forum_ai_notetaker/db.py
+++ b/backend/forum_ai_notetaker/db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 from contextlib import contextmanager
 from pathlib import Path
@@ -83,7 +84,11 @@ def _run_migrations(connection: sqlite3.Connection) -> None:
 
 
 def resolve_db_path(db_path: str | Path | None = None) -> Path:
-    path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+    if db_path is not None:
+        path = Path(db_path)
+    else:
+        env_path = os.environ.get("DATABASE_PATH")
+        path = Path(env_path) if env_path else DEFAULT_DB_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -92,6 +97,10 @@ def init_db(db_path: str | Path | None = None) -> Path:
     path = resolve_db_path(db_path)
     schema = SCHEMA_PATH.read_text(encoding="utf-8")
     with sqlite3.connect(path) as connection:
+        # WAL mode lets readers and writers proceed concurrently. Without
+        # it, background pipeline writes (transcript, notes, status) block
+        # foreground reads and raise "database is locked" errors.
+        connection.execute("PRAGMA journal_mode = WAL;")
         connection.execute("PRAGMA foreign_keys = ON;")
         connection.executescript(schema)
         _run_migrations(connection)
@@ -100,9 +109,10 @@ def init_db(db_path: str | Path | None = None) -> Path:
 
 @contextmanager
 def get_connection(db_path: str | Path | None = None) -> Iterator[sqlite3.Connection]:
-    connection = sqlite3.connect(resolve_db_path(db_path))
+    connection = sqlite3.connect(resolve_db_path(db_path), timeout=10.0)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON;")
+    connection.execute("PRAGMA busy_timeout = 5000;")
     try:
         yield connection
     finally:

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -10,7 +10,9 @@ These routes form the public authentication API of the backend:
 - /me returns the authenticated user's identity using shared auth middleware
 """
 
+import os
 import re
+import secrets
 import sqlite3
 
 from flask import Blueprint, request, g
@@ -65,6 +67,20 @@ def register():
 
     if errors:
         return error_response("; ".join(errors), 400)
+
+    # Gate professor self-registration so random visitors on the public URL
+    # cannot create privileged accounts and burn our Groq/Whisper quota.
+    # In prod the app.py startup guard already requires this env var to be
+    # set; here we enforce it at request time too. If the env var is unset
+    # (local dev only — Railway boot would have failed), the gate is open.
+    if user_type == "professor":
+        expected_secret = os.environ.get("PROFESSOR_REGISTRATION_SECRET", "")
+        if expected_secret:
+            provided_secret = (data.get("professor_secret") or "").strip()
+            if not provided_secret or not secrets.compare_digest(
+                provided_secret, expected_secret
+            ):
+                return error_response("Invalid professor registration secret", 403)
 
     password_hash = generate_password_hash(password, method="pbkdf2:sha256")
 

--- a/backend/routes/sessions.py
+++ b/backend/routes/sessions.py
@@ -15,6 +15,7 @@ only see sessions belonging to courses they are enrolled in.
 """
 
 import mimetypes
+import os
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -38,6 +39,34 @@ from utils.validators import allowed_file, safe_filename
 executor = ThreadPoolExecutor(max_workers=2)
 
 sessions_bp = Blueprint("sessions", __name__)
+
+
+@sessions_bp.after_request
+def allow_cors_on_media(response):
+    """
+    Flask-CORS does not reliably attach Access-Control-Allow-Origin to
+    206 Partial Content responses (which browsers issue for <video> seeking).
+    Without this hook, Safari/Chrome drop the media stream cross-origin.
+    """
+    if "/media" not in request.path:
+        return response
+
+    raw_origins = os.environ.get("CORS_ORIGINS", "*").strip()
+    origin = request.headers.get("Origin", "")
+    if raw_origins == "*":
+        # Write literal "*" rather than reflecting the request origin.
+        # Reflection + credentials would silently trust every origin.
+        response.headers["Access-Control-Allow-Origin"] = "*"
+    else:
+        allowed = {o.strip() for o in raw_origins.split(",") if o.strip()}
+        if origin and origin in allowed:
+            response.headers["Access-Control-Allow-Origin"] = origin
+    # Ensure caches key responses per-origin so ACAO can't be reused across origins.
+    response.headers["Vary"] = "Origin"
+    response.headers["Access-Control-Expose-Headers"] = (
+        "Content-Range, Accept-Ranges, Content-Length"
+    )
+    return response
 
 
 @sessions_bp.route("/", methods=["GET"])

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,13 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .
+
+# Baked into the Vite build so the SPA knows the absolute backend URL on
+# Railway (where frontend and backend are separate services, not same-origin).
+# Empty at local compose build = falls back to relative /api via nginx proxy.
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+
 RUN npm run build
 
 FROM nginx:alpine

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,20 +5,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Large upload ceiling for lecture recordings.
+    # Large upload ceiling kept for any direct POSTs routed via this nginx.
     client_max_body_size 500M;
 
-    location /api/ {
-        proxy_pass http://backend:5000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 600s;
-        proxy_send_timeout 600s;
-    }
-
+    # The /api/ proxy to backend:5000 was removed because on Railway the
+    # backend is a separate service, not a docker-compose sibling. The SPA
+    # now reads VITE_API_BASE_URL (baked in at build time) and makes
+    # absolute calls directly to the backend's public URL.
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/frontend/src/api/backend.js
+++ b/frontend/src/api/backend.js
@@ -1,6 +1,20 @@
 // Use an env override when needed; otherwise rely on Vite proxy (/api -> backend).
 const API_BASE = import.meta.env.VITE_API_BASE_URL || "";
 
+// If a production build forgot to bake VITE_API_BASE_URL, relative /api calls
+// hit the nginx container (which no longer proxies to the backend) and fail
+// silently with 404s. Warn loudly so the misconfiguration is obvious.
+if (!import.meta.env.DEV && !API_BASE && typeof window !== "undefined") {
+  const host = window.location.hostname;
+  if (host !== "localhost" && host !== "127.0.0.1") {
+    // eslint-disable-next-line no-console
+    console.error(
+      "[config] VITE_API_BASE_URL was not set at build time. " +
+      "API calls will fail. Set it as a Railway build arg on the frontend service."
+    );
+  }
+}
+
 function getToken() {
   return localStorage.getItem("token");
 }


### PR DESCRIPTION
## Summary

Makes the app deployable to Railway as two services (backend + frontend) with auto-redeploy on every push to `main`. Also closes a handful of security gaps that existed before (JWT fallback secret, open professor self-registration, no upload size cap at the Flask layer, no WAL journal mode on SQLite).

None of the changes affect local `dev.sh` flow — every new env var has a safe default that matches prior behavior when unset.

## Approach

**Backend:**
- `Dockerfile` CMD switches to shell form so Railway's `$PORT` expands; gunicorn tuned for Whisper (1 worker, 2 threads, 30-min timeout).
- `DATABASE_PATH` and `UPLOAD_FOLDER` become env vars, resolved lazily so they can point at Railway volumes in prod.
- `CORS_ORIGINS` env var; passes `"*"` as a string (not `["*"]`) to flask-cors so credentialed semantics stay correct.
- `MAX_CONTENT_LENGTH` cap of 500 MB at the Flask layer — direct POSTs to the backend URL bypass the nginx cap on the frontend service.
- Startup guards fail the boot (via `RuntimeError`, which Railway catches as a deploy failure) when `RAILWAY_ENVIRONMENT` is set and `JWT_SECRET_KEY` or `PROFESSOR_REGISTRATION_SECRET` are missing/`CHANGE_ME`/`dev-secret-key`. Local dev is unaffected.
- `PROFESSOR_REGISTRATION_SECRET` gates `POST /api/auth/register` when `user_type=professor`.
- `@sessions_bp.after_request` hook adds `Access-Control-Allow-Origin`, `Vary: Origin`, and `Access-Control-Expose-Headers` on `/media` responses — flask-cors doesn't reliably attach ACAO to 206 Partial Content, which breaks `<video>` seeking on Safari.
- SQLite WAL mode + `busy_timeout=5000ms` + 10s connect timeout so background pipeline writes (transcript, notes, status) don't block foreground reads under prof-test load.

**Frontend:**
- `Dockerfile` accepts `VITE_API_BASE_URL` as a build arg and bakes it into the Vite build.
- `nginx.conf` drops the `/api/` → `http://backend:5000` proxy block; that hostname doesn't resolve on Railway (services aren't docker-compose siblings). SPA now calls the backend's public URL directly.
- `backend.js` logs a clear `console.error` in prod builds when `VITE_API_BASE_URL` is empty and the host isn't `localhost` — makes build-arg misconfigurations obvious instead of silent 404s.

**Config:**
- `.env.example` documents all new vars with `CHANGE_ME` placeholders.
- `.gitignore` adds `local-work/`, `.serena/`, `*.log`, `*.excalidraw`, and SQLite WAL/SHM sidecar files.

## Test plan

- [x] Local `dev.sh` still boots with the existing `.env` (guards pass because `RAILWAY_ENVIRONMENT` is unset locally).
- [x] Full upload → transcribe → notes pipeline runs end-to-end locally (`notes_generated` in ~16s on a 98s mp4).
- [x] Professor registration stays open locally when `PROFESSOR_REGISTRATION_SECRET` is unset.
- [x] SQLite `PRAGMA journal_mode` reports `wal` after boot.
- [x] `/api/sessions/:id/media` response includes `Access-Control-Allow-Origin: *`, `Vary: Origin`, `Access-Control-Expose-Headers`.
- [x] Startup guard fires with `JWT_SECRET_KEY=CHANGE_ME` + `RAILWAY_ENVIRONMENT=production`.
- [x] Startup guard fires when `PROFESSOR_REGISTRATION_SECRET` missing in prod.
- [x] Frontend `npm run build` with `VITE_API_BASE_URL=<url>` bakes the URL into the output bundle.
- [ ] Deploy both services on Railway, verify auto-redeploy on next push to `main`.
- [ ] Smoke test full flow against deployed URLs (register, create course, upload, wait for notes).

## Known follow-ups (not in this PR)

- `docker-compose up` locally no longer works end-to-end (nginx `/api/` proxy removed). Team uses `dev.sh` so this is acceptable.
- `pipeline/audio.py` writes extracted WAVs to a hardcoded path inside `backend_root/uploads/audio`. Happens to land inside the upload volume on Railway but should read `UPLOAD_FOLDER` for clarity — deferred.
- Railway's public proxy has a 30s request timeout; uploads over ~50 MB will fail at ingress before reaching Flask. Not code, just an expectation to document.